### PR TITLE
fix: 덱 버튼 페이지 이동 후 덱 버튼 클릭 시 카드 상태 초기화 문제 해결[ETWGL-65, 125]

### DIFF
--- a/src/my_deck_card/repository/MyDeckCardMapRepositoryImpl.ts
+++ b/src/my_deck_card/repository/MyDeckCardMapRepositoryImpl.ts
@@ -13,6 +13,12 @@ import {MyDeckCardMapRepository} from "./MyDeckCardMapRepository";
                  30, 32, 40, 43, 47, 49, 55, 56]);
             this.currentMyDeckCardMap.set(2,
                 [5, 8, 8, 19, 20, 33, 35, 29, 30, 40, 56, 55, 2, 93]);
+            this.currentMyDeckCardMap.set(3, [19, 33, 35, 40, 55, 29, 70, 71]);
+            this.currentMyDeckCardMap.set(4, [70, 71, 72, 74, 76, 77, 99, 119]);
+            this.currentMyDeckCardMap.set(5, [129, 130, 133, 134, 139, 141, 143, 145]);
+            this.currentMyDeckCardMap.set(6, [30, 32, 40, 43, 47, 49, 55, 56]);
+            this.currentMyDeckCardMap.set(7, [35, 29, 30, 40, 56, 55, 2, 93]);
+            this.currentMyDeckCardMap.set(8, [19, 20, 93, 26, 27, 2, 14, 15]);
         }
 
         public static getInstance(): MyDeckCardMapRepositoryImpl {


### PR DESCRIPTION
페이지 이동 시 덱 버튼 상태는 초기화되지만 카드 상태가 초기화되지 않아 발생한 문제를 해결