### PR TITLE
refactor: [이재림] 덱 버튼 클릭 이벤트 구조 개선 [ETWGL-301]

### DIFF
--- a/src/deck_button_click_detect/service/MyDeckButtonClickDetectService.ts
+++ b/src/deck_button_click_detect/service/MyDeckButtonClickDetectService.ts
@@ -3,6 +3,7 @@ export interface MyDeckButtonClickDetectService {
         clickPoint: { x: number; y: number },
     ): any | null;
     onMouseDown(event: MouseEvent): Promise<any | null>;
+    onMouseUp(event: MouseEvent): Promise<any | null>;
     saveCurrentClickDeckButtonId(buttonDeckId: number): void;
     getCurrentClickDeckButtonId(): number | null;
 }

--- a/src/deck_button_click_detect/service/MyDeckButtonClickDetectServiceImpl.ts
+++ b/src/deck_button_click_detect/service/MyDeckButtonClickDetectServiceImpl.ts
@@ -248,12 +248,8 @@ export class MyDeckButtonClickDetectServiceImpl implements MyDeckButtonClickDete
                 this.setNumberOfSelectedCardsVisibilityByDeckId(currentClickedDeckButtonId, true);
                 this.setDeckCardCountMarkerVisibilityByDeckId(currentClickedDeckButtonId, true);
 
-                setTimeout(() => {
-                    this.setDeckNameEditButtonVisibility(currentClickedDeckButtonId, true);
-                    this.setDeckDeleteButtonVisibility(currentClickedDeckButtonId, true);
-
-                    this.deckDeleteButtonClickDetectRepository.saveButtonClickEnabled(currentClickedDeckButtonId, true);
-                }, 10);
+                this.setDeckNameEditButtonVisibility(currentClickedDeckButtonId, true);
+                this.setDeckDeleteButtonVisibility(currentClickedDeckButtonId, true);
 
                 console.log(`Deck Button ID ${currentClickedDeckButtonId} is now hidden.`);
             }
@@ -275,6 +271,19 @@ export class MyDeckButtonClickDetectServiceImpl implements MyDeckButtonClickDete
                 this.deckEditDoneButtonHoverDetectRepository.setButtonHoverEnabled(false);
                 return result;
             }
+        }
+        return null;
+    }
+
+    public async onMouseUp(event: MouseEvent): Promise<MyDeckButton | null> {
+        if (!this.isButtonClickEnabled()) return null;
+
+        if (event.button === 0) {
+            const deckButtonId = this.getCurrentClickDeckButtonId();
+            if (deckButtonId == null) return null;
+
+            this.deckDeleteButtonClickDetectRepository.saveButtonClickEnabled(deckButtonId, true);
+
         }
         return null;
     }

--- a/src/deck_delete_button_click_detect/service/DeckDeleteButtonClickDetectServiceImpl.ts
+++ b/src/deck_delete_button_click_detect/service/DeckDeleteButtonClickDetectServiceImpl.ts
@@ -76,8 +76,11 @@ export class DeckDeleteButtonClickDetectServiceImpl implements DeckDeleteButtonC
 
         const deleteDeckButtonVisible = this.getDeckDeleteButtonVisibility(currentClickedDeckId);
         console.log(`%c 버튼 visible 상태?: ${deleteDeckButtonVisible}`, 'color: #00d5ff; font-weight: bold;');
+        if (deleteDeckButtonVisible !== true) return null;
 
-        if (this.isDeckDeleteButtonClickEnabled(currentClickedDeckId) !== true && deleteDeckButtonVisible == false) return null;
+        const deckDeleteButtonClickEnabled = this.isDeckDeleteButtonClickEnabled(currentClickedDeckId);
+        console.log(`%c 버튼 클릭 가능?: ${deckDeleteButtonClickEnabled}`, 'color: #00d5ff; font-weight: bold;');
+        if (deckDeleteButtonClickEnabled !== true) return null;
 
         if (event.button === 0) {
             const clickPoint = { x: event.clientX, y: event.clientY };

--- a/test/refactor_draw_my_deck/refactor_draw_my_deck.ts
+++ b/test/refactor_draw_my_deck/refactor_draw_my_deck.ts
@@ -277,6 +277,7 @@ export class TCGJustTestMyDeckView {
         this.deckCardSearchInputChangeDetectService = DeckCardSearchInputChangeDetectServiceImpl.getInstance(this.camera, this.scene);
 
         this.renderer.domElement.addEventListener('mousedown', (e) => this.myDeckButtonClickDetectService.onMouseDown(e), false);
+        this.renderer.domElement.addEventListener('mouseup', (e) => this.myDeckButtonClickDetectService.onMouseUp(e), false);
         this.renderer.domElement.addEventListener('mousemove', (e) => this.sideScrollAreaDetectService.onMouseMoveMyDeck(e), false);
         this.renderer.domElement.addEventListener('mousemove', (e) => this.buildDeckButtonHoverDetectService.onMouseMove(e), false);
         this.renderer.domElement.addEventListener('wheel', (e) => this.myDeckScrollService.onWheelScroll(e), false);


### PR DESCRIPTION
- 기존 setTimeout 방식 제거
- 덱 버튼 mousedown 시 덱 이름 편집/삭제 버튼 표시
- 덱 버튼 mouseup 시 버튼 클릭 가능하도록 분리
- 덱 버튼 클릭 시 편집/삭제 버튼 중복 클릭 문제 해결