### PR TITLE
feat: [이재림] My Deck의 특정 버튼 클릭 시 카드 검색창 입력 상태 제어 [ETWGL-396, 393]

### DIFF
--- a/src/build_deck_button_click_detect/service/BuildDeckButtonClickDetectServiceImpl.ts
+++ b/src/build_deck_button_click_detect/service/BuildDeckButtonClickDetectServiceImpl.ts
@@ -75,15 +75,9 @@ export class BuildDeckButtonClickDetectServiceImpl implements BuildDeckButtonCli
             if (clickedButton) {
                 console.log(`[DEBUG] Clicked Build Deck Button`);
 
-                const searchInputText = this.myDeckSearchInputContainerRepository.findInputValue();
-                if (searchInputText !== null && searchInputText.length > 0) {
-                    this.myDeckSearchInputContainerRepository.clearUserInput();
-                    this.myDeckSearchInputContainerRepository.deleteUserInput();
-                }
-
                 const searchContainer = this.myDeckSearchInputContainerRepository.findMyDeckSearchInputContainer();
                 if (searchContainer) {
-                    searchContainer.setVisibility('none');
+                    searchContainer.setInputDisabled(true);
                 }
 
                 this.setSearchCancelButtonVisibility(false);

--- a/src/deck_button_click_detect/repository/MyDeckButtonClickDetectRepositoryImpl.ts
+++ b/src/deck_button_click_detect/repository/MyDeckButtonClickDetectRepositoryImpl.ts
@@ -42,14 +42,14 @@ export class MyDeckButtonClickDetectRepositoryImpl implements MyDeckButtonClickD
 
             const prevClickedDeckButtonId = this.getCurrentClickDeckButtonId();
             if (prevClickedDeckButtonId !== null) {
-                console.log(`%c 이전에 클릭한 덱 버튼의 ID: ${prevClickedDeckButtonId}`, 'color: #ff5733; font-weight: bold;');
+                console.log(`%c [버튼 클릭 이벤트 아직 미실행] 이전에 클릭한 덱 버튼의 ID: ${prevClickedDeckButtonId}`, 'color: #ff5733; font-weight: bold;');
             }
 
             if (clickedDeckButton) {
-                console.log('%c detect clicked deck Button!', 'color: #ff5733; font-weight: bold;')
+                console.log('%c [버튼 클릭 이벤트 아직 미실행] detect clicked deck Button!', 'color: #ff5733; font-weight: bold;')
 
                 const buttonClickState = this.getButtonClickState(clickedDeckButton.id);
-                console.log(`%c 현재 감지된 덱 버튼의 ID: ${clickedDeckButton.id}, 버튼의 클릭 상태: ${buttonClickState}`, 'color: #ff5733; font-weight: bold;');
+                console.log(`%c [버튼 클릭 이벤트 아직 미실행] 현재 감지된 덱 버튼의 ID: ${clickedDeckButton.id}, 버튼의 클릭 상태: ${buttonClickState}`, 'color: #ff5733; font-weight: bold;');
 
                 if (prevClickedDeckButtonId !== null && prevClickedDeckButtonId !== clickedDeckButton.id) {
                     this.saveButtonClickState(prevClickedDeckButtonId, false);

--- a/src/deck_button_click_detect/service/MyDeckButtonClickDetectServiceImpl.ts
+++ b/src/deck_button_click_detect/service/MyDeckButtonClickDetectServiceImpl.ts
@@ -223,7 +223,7 @@ export class MyDeckButtonClickDetectServiceImpl implements MyDeckButtonClickDete
 
             const buttonId = clickedDeckButton.id;
             const currentClickedDeckId = this.getDeckIdByButtonId(buttonId);
-            console.log(`Clicked Deck Button ID: ${buttonId}, Deck ID: ${currentClickedDeckId}`);
+            console.log(`%c [버튼 클릭 이벤트 실행] 현재 클릭된 덱 버튼의 ID: ${buttonId}, 덱 ID: ${currentClickedDeckId}`, 'color: #ff5733; font-weight: bold;');
             this.saveCurrentClickDeckId(currentClickedDeckId);
 
             if (currentClickedDeckId !== null) {

--- a/src/deck_delete_button_click_detect/service/DeckDeleteButtonClickDetectServiceImpl.ts
+++ b/src/deck_delete_button_click_detect/service/DeckDeleteButtonClickDetectServiceImpl.ts
@@ -5,6 +5,7 @@ import {DeckDeleteButtonClickDetectService} from "./DeckDeleteButtonClickDetectS
 import {DeckDeleteButtonClickDetectRepositoryImpl} from "../repository/DeckDeleteButtonClickDetectRepositoryImpl";
 import {DeckDeleteButton} from "../../deck_delete_button/entity/DeckDeleteButton";
 import {DeckDeleteButtonRepositoryImpl} from "../../deck_delete_button/repository/DeckDeleteButtonRepositoryImpl";
+import {MyDeckSearchInputContainerRepositoryImpl} from "../../my_deck_search_input_container/repository/MyDeckSearchInputContainerRepositoryImpl";
 
 import {CameraRepository} from "../../camera/repository/CameraRepository";
 import {CameraRepositoryImpl} from "../../camera/repository/CameraRepositoryImpl";
@@ -25,6 +26,7 @@ export class DeckDeleteButtonClickDetectServiceImpl implements DeckDeleteButtonC
     private deleteDeckPopupButtonRepository: DeleteDeckPopupButtonRepositoryImpl;
     private myDeckButtonClickDetectRepository: MyDeckButtonClickDetectRepositoryImpl;
     private myDeckButtonRepository: MyDeckButtonRepositoryImpl;
+    private myDeckSearchInputContainerRepository: MyDeckSearchInputContainerRepositoryImpl;
 
     private constructor(private camera: THREE.Camera, private scene: THREE.Scene) {
         this.cameraRepository = CameraRepositoryImpl.getInstance();
@@ -35,6 +37,7 @@ export class DeckDeleteButtonClickDetectServiceImpl implements DeckDeleteButtonC
         this.deleteDeckPopupButtonRepository = DeleteDeckPopupButtonRepositoryImpl.getInstance();
         this.myDeckButtonClickDetectRepository = MyDeckButtonClickDetectRepositoryImpl.getInstance();
         this.myDeckButtonRepository = MyDeckButtonRepositoryImpl.getInstance(scene);
+        this.myDeckSearchInputContainerRepository = MyDeckSearchInputContainerRepositoryImpl.getInstance();
     }
 
     static getInstance(camera: THREE.Camera, scene: THREE.Scene): DeckDeleteButtonClickDetectServiceImpl {
@@ -57,6 +60,11 @@ export class DeckDeleteButtonClickDetectServiceImpl implements DeckDeleteButtonC
             const buttonId = clickedButton.id;
             console.log(`[DEBUG] Clicked Deck Delete Button ID: ${buttonId}`);
 
+            const searchContainer = this.myDeckSearchInputContainerRepository.findMyDeckSearchInputContainer();
+            if (searchContainer) {
+                searchContainer.setInputDisabled(true);
+            }
+
             const deckId = this.getDeckIdByDeleteButtonId(buttonId);
             if (deckId == null) return null;
 
@@ -75,7 +83,7 @@ export class DeckDeleteButtonClickDetectServiceImpl implements DeckDeleteButtonC
     public async onMouseDown(event: MouseEvent): Promise<DeckDeleteButton | null> {
         const currentClickedDeckId = this.myDeckButtonClickDetectRepository.getCurrentClickDeckId();
         if (currentClickedDeckId == null) return null;
-        console.log(`%c 현재 클릭한 덱 ID?: ${currentClickedDeckId}`, 'color: #00d5ff; font-weight: bold;');
+//         console.log(`%c 현재 클릭한 덱 ID?: ${currentClickedDeckId}`, 'color: #00d5ff; font-weight: bold;');
 
         const deleteDeckButtonVisible = this.getDeckDeleteButtonVisibility(currentClickedDeckId);
         console.log(`%c 덱 삭제 버튼 visible 상태?: ${deleteDeckButtonVisible}`, 'color: #00d5ff; font-weight: bold;');

--- a/src/deck_make_pop_up_buttons_click_detect/service/DeckMakePopupButtonsClickDetectServiceImpl.ts
+++ b/src/deck_make_pop_up_buttons_click_detect/service/DeckMakePopupButtonsClickDetectServiceImpl.ts
@@ -64,7 +64,7 @@ export class DeckMakePopupButtonsClickDetectServiceImpl implements DeckMakePopup
 
             const searchContainer = this.myDeckSearchInputContainerRepository.findMyDeckSearchInputContainer();
             if (searchContainer) {
-                searchContainer.setVisibility('block');
+                searchContainer.setInputDisabled(false);
             }
 
             if (clickedDeckMakePopupButton.id === 0) {
@@ -78,6 +78,14 @@ export class DeckMakePopupButtonsClickDetectServiceImpl implements DeckMakePopup
 
             if (clickedDeckMakePopupButton.id === 1) {
                 console.log(`[DEBUG] click create button!`);
+
+                // 덱 생성 버튼을 클릭하면 다른 페이지로 넘어가므로 검색창에 입력되어 있는 텍스트가 지워져야 함
+                const searchInputText = this.myDeckSearchInputContainerRepository.findInputValue();
+                if (searchInputText !== null && searchInputText.length > 0) {
+                    this.myDeckSearchInputContainerRepository.clearUserInput();
+                    this.myDeckSearchInputContainerRepository.deleteUserInput();
+                }
+
                 this.saveUserInput();
                 this.clearUserInput();
                 this.deckMakePopupInputContainerRepository.findUserInput();

--- a/src/deck_name_edit_button_click_detect/service/DeckNameEditButtonClickDetectServiceImpl.ts
+++ b/src/deck_name_edit_button_click_detect/service/DeckNameEditButtonClickDetectServiceImpl.ts
@@ -9,6 +9,7 @@ import {DeckNameEditButtonClickDetectRepositoryImpl} from "../repository/DeckNam
 import {DeckNameEditButton} from "../../deck_name_edit_button/entity/DeckNameEditButton";
 import {DeckNameEditButtonRepositoryImpl} from "../../deck_name_edit_button/repository/DeckNameEditButtonRepositoryImpl";
 import {MyDeckButtonClickDetectRepositoryImpl} from "../../deck_button_click_detect/repository/MyDeckButtonClickDetectRepositoryImpl";
+import {MyDeckSearchInputContainerRepositoryImpl} from "../../my_deck_search_input_container/repository/MyDeckSearchInputContainerRepositoryImpl";
 
 export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditButtonClickDetectService {
     private static instance: DeckNameEditButtonClickDetectServiceImpl | null = null;
@@ -16,12 +17,14 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
     private deckNameEditButtonClickDetectRepository: DeckNameEditButtonClickDetectRepositoryImpl;
     private deckNameEditButtonRepository: DeckNameEditButtonRepositoryImpl;
     private myDeckButtonClickDetectRepository: MyDeckButtonClickDetectRepositoryImpl;
+    private myDeckSearchInputContainerRepository: MyDeckSearchInputContainerRepositoryImpl;
 
     private constructor(private camera: THREE.Camera, private scene: THREE.Scene) {
         this.cameraRepository = CameraRepositoryImpl.getInstance();
         this.deckNameEditButtonClickDetectRepository = DeckNameEditButtonClickDetectRepositoryImpl.getInstance();
         this.deckNameEditButtonRepository = DeckNameEditButtonRepositoryImpl.getInstance(scene);
         this.myDeckButtonClickDetectRepository = MyDeckButtonClickDetectRepositoryImpl.getInstance();
+        this.myDeckSearchInputContainerRepository = MyDeckSearchInputContainerRepositoryImpl.getInstance();
     }
 
     static getInstance(camera: THREE.Camera, scene: THREE.Scene): DeckNameEditButtonClickDetectServiceImpl {
@@ -45,6 +48,11 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
             console.log(`[DEBUG] Clicked Deck Name Edit Button ID: ${buttonId}`);
             this.saveCurrentClickedDeckNameEditButtonId(buttonId);
 
+            const searchContainer = this.myDeckSearchInputContainerRepository.findMyDeckSearchInputContainer();
+            if (searchContainer) {
+                searchContainer.setInputDisabled(true);
+            }
+
             return clickedButton;
 
         }
@@ -54,7 +62,7 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
     public async onMouseDown(event: MouseEvent): Promise<DeckNameEditButton | null> {
         const currentClickedDeckId = this.myDeckButtonClickDetectRepository.getCurrentClickDeckId();
         if (currentClickedDeckId == null) return null;
-        console.log(`%c 현재 클릭한 덱 ID?: ${currentClickedDeckId}`, 'color: #00d5ff; font-weight: bold;');
+//         console.log(`%c 현재 클릭한 덱 ID?: ${currentClickedDeckId}`, 'color: #00d5ff; font-weight: bold;');
 
         const deckNameEditButtonVisible = this.getDeckNameEditButtonVisibility(currentClickedDeckId);
         console.log(`%c 덱 이름 편집 버튼 visible 상태?: ${deckNameEditButtonVisible}`, 'color: #00d5ff; font-weight: bold;');

--- a/src/delete_deck_popup_button_click_detect/service/DeleteDeckPopupButtonClickDetectServiceImpl.ts
+++ b/src/delete_deck_popup_button_click_detect/service/DeleteDeckPopupButtonClickDetectServiceImpl.ts
@@ -34,6 +34,7 @@ import {MyDeckCardNamePositionRepositoryImpl} from "../../my_deck_card_name_posi
 import {MyDeckNumberOfCardsPositionRepositoryImpl} from "../../my_deck_number_of_cards_position/repository/MyDeckNumberOfCardsPositionRepositoryImpl";
 import {DeckCardCountMarkerPositionRepositoryImpl} from "../../deck_card_count_marker_position/repository/DeckCardCountMarkerPositionRepositoryImpl";
 import {MyDeckNumberOfSelectedCardsPositionRepositoryImpl} from "../../my_deck_number_of_selected_cards_position/repository/MyDeckNumberOfSelectedCardsPositionRepositoryImpl";
+import {MyDeckSearchInputContainerRepositoryImpl} from "../../my_deck_search_input_container/repository/MyDeckSearchInputContainerRepositoryImpl";
 
 import {MyDeckButtonMapRepositoryImpl} from "../../my_deck_button/repository/MyDeckButtonMapRepositoryImpl";
 import {MyDeckCardMapRepositoryImpl} from "../../my_deck_card/repository/MyDeckCardMapRepositoryImpl";
@@ -68,6 +69,7 @@ export class DeleteDeckPopupButtonClickDetectServiceImpl implements DeleteDeckPo
     private myDeckNumberOfCardsRepository: MyDeckNumberOfCardsRepositoryImpl;
     private deckCardCountMarkerRepository: DeckCardCountMarkerRepositoryImpl;
     private myDeckNumberOfSelectedCardsRepository: MyDeckNumberOfSelectedCardsRepositoryImpl;
+    private myDeckSearchInputContainerRepository: MyDeckSearchInputContainerRepositoryImpl;
 
     private deckDeleteButtonPositionRepository: DeckDeleteButtonPositionRepositoryImpl;
     private deckNameEditButtonPositionRepository: DeckNameEditButtonPositionRepositoryImpl;
@@ -109,6 +111,7 @@ export class DeleteDeckPopupButtonClickDetectServiceImpl implements DeleteDeckPo
         this.myDeckNumberOfCardsRepository = MyDeckNumberOfCardsRepositoryImpl.getInstance(scene);
         this.deckCardCountMarkerRepository = DeckCardCountMarkerRepositoryImpl.getInstance(scene);
         this.myDeckNumberOfSelectedCardsRepository = MyDeckNumberOfSelectedCardsRepositoryImpl.getInstance(scene);
+        this.myDeckSearchInputContainerRepository = MyDeckSearchInputContainerRepositoryImpl.getInstance();
 
         this.deckDeleteButtonPositionRepository = DeckDeleteButtonPositionRepositoryImpl.getInstance();
         this.deckNameEditButtonPositionRepository = DeckNameEditButtonPositionRepositoryImpl.getInstance();
@@ -161,6 +164,10 @@ export class DeleteDeckPopupButtonClickDetectServiceImpl implements DeleteDeckPo
             this.setPopupWindowVisibility(false);
             this.setPopupButtonsVisibility(false);
 
+            const searchContainer = this.myDeckSearchInputContainerRepository.findMyDeckSearchInputContainer();
+            if (searchContainer) {
+                searchContainer.setInputDisabled(false);
+            }
 
             switch (currentClickedButtonId) {
                 case 0:
@@ -168,6 +175,13 @@ export class DeleteDeckPopupButtonClickDetectServiceImpl implements DeleteDeckPo
                     break;
                 case 1:
                     console.log(`Deck Delete!`);
+
+                    const searchInputText = this.myDeckSearchInputContainerRepository.findInputValue();
+                    if (searchInputText !== null && searchInputText.length > 0) {
+                        this.myDeckSearchInputContainerRepository.clearUserInput();
+                        this.myDeckSearchInputContainerRepository.deleteUserInput();
+                    }
+
                     const deleteDeckId = this.getCurrentDeleteDeckId();
                     if (deleteDeckId == null) return null;
 

--- a/src/my_deck_search_input_container/entity/MyDeckSearchInputContainer.ts
+++ b/src/my_deck_search_input_container/entity/MyDeckSearchInputContainer.ts
@@ -30,6 +30,14 @@ export class MyDeckSearchInputContainer {
         return this.container.style.display;
     }
 
+    public setInputDisabled(isDisabled: boolean): void {
+        this.inputElement.disabled = isDisabled;
+    }
+
+    public isInputDisabled(): boolean {
+        return this.inputElement.disabled;
+    }
+
 //     public getVisibility(): CSSStyleDeclaration['display'] {
 //         return this.container.style.display;
 //     }


### PR DESCRIPTION
- 덱 생성/이름 편집/삭제 버튼 클릭 시: 기존 텍스트 유지, 입력 및 검색 기능 비활성화
- 덱 삭제/생성 팝업 버튼 클릭 시: 입력 및 검색 기능 활성화
- 덱 삭제 팝업 '삭제' 버튼 클릭 시: 검색창 텍스트 제거
- 덱 생성 팝업 '생성' 버튼 클릭 시: 검색창 텍스트 제거