### PR TITLE
feat: [이재림] 덱 이름 편집 팝업창의 취소 버튼 클릭시 기존의 My Deck 화면으로 복귀 [ETWGL-411]

### DIFF
--- a/src/deck_name_edit_button_click_detect/service/DeckNameEditButtonClickDetectServiceImpl.ts
+++ b/src/deck_name_edit_button_click_detect/service/DeckNameEditButtonClickDetectServiceImpl.ts
@@ -15,6 +15,7 @@ import {TransparentBackgroundRepositoryImpl} from "../../transparent_background/
 import {DeckNameEditPopupBackgroundRepositoryImpl} from "../../deck_name_edit_pop_up_background/repository/DeckNameEditPopupBackgroundRepositoryImpl";
 import {DeckNameEditPopupButtonsRepositoryImpl} from "../../deck_name_edit_pop_up_buttons/repository/DeckNameEditPopupButtonsRepositoryImpl";
 import {DeckNameEditInputContainerRepositoryImpl} from "../../deck_name_edit_input_container/repository/DeckNameEditInputContainerRepositoryImpl";
+import {DeckNameEditPopupButtonsClickDetectRepositoryImpl} from "../../deck_name_edit_pop_up_buttons_click_detect/repository/DeckNameEditPopupButtonsClickDetectRepositoryImpl";
 
 export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditButtonClickDetectService {
     private static instance: DeckNameEditButtonClickDetectServiceImpl | null = null;
@@ -28,6 +29,7 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
     private deckNameEditPopupBackgroundRepository: DeckNameEditPopupBackgroundRepositoryImpl;
     private deckNameEditPopupButtonsRepository: DeckNameEditPopupButtonsRepositoryImpl;
     private deckNameEditInputContainerRepository: DeckNameEditInputContainerRepositoryImpl;
+    private deckNameEditPopupButtonsClickDetectRepository: DeckNameEditPopupButtonsClickDetectRepositoryImpl;
 
     private constructor(private camera: THREE.Camera, private scene: THREE.Scene) {
         this.cameraRepository = CameraRepositoryImpl.getInstance();
@@ -40,6 +42,7 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
         this.deckNameEditPopupBackgroundRepository = DeckNameEditPopupBackgroundRepositoryImpl.getInstance();
         this.deckNameEditPopupButtonsRepository = DeckNameEditPopupButtonsRepositoryImpl.getInstance();
         this.deckNameEditInputContainerRepository = DeckNameEditInputContainerRepositoryImpl.getInstance();
+        this.deckNameEditPopupButtonsClickDetectRepository = DeckNameEditPopupButtonsClickDetectRepositoryImpl.getInstance();
     }
 
     static getInstance(camera: THREE.Camera, scene: THREE.Scene): DeckNameEditButtonClickDetectServiceImpl {
@@ -99,6 +102,7 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
             const result = await this.handleButtonClick(clickPoint);
             if (result) {
                 this.setDeckNameEditButtonClickEnabled(currentClickedDeckId, false);
+                this.setDeckNameEditPopupButtonsClickEnabled(true);
             }
         }
         return null;
@@ -130,6 +134,10 @@ export class DeckNameEditButtonClickDetectServiceImpl implements DeckNameEditBut
 
     private setSearchCancelButtonClickEnabled(isEnable: boolean): void {
         this.deckCardSearchCancelButtonClickDetectRepository.setButtonClickEnabled(isEnable);
+    }
+
+    private setDeckNameEditPopupButtonsClickEnabled(isEnabled: boolean): void {
+        this.deckNameEditPopupButtonsClickDetectRepository.setButtonClickEnabled(isEnabled);
     }
 
     private setTransparentBackgroundVisible(isVisible: boolean): void {

--- a/src/deck_name_edit_pop_up_buttons_click_detect/service/DeckNameEditPopupButtonsClickDetectServiceImpl.ts
+++ b/src/deck_name_edit_pop_up_buttons_click_detect/service/DeckNameEditPopupButtonsClickDetectServiceImpl.ts
@@ -9,16 +9,26 @@ import {DeckNameEditPopupButtonsRepositoryImpl} from "../../deck_name_edit_pop_u
 import {CameraRepository} from "../../camera/repository/CameraRepository";
 import {CameraRepositoryImpl} from "../../camera/repository/CameraRepositoryImpl";
 
+import {TransparentBackgroundRepositoryImpl} from "../../transparent_background/repository/TransparentBackgroundRepositoryImpl";
+import {DeckNameEditPopupBackgroundRepositoryImpl} from "../../deck_name_edit_pop_up_background/repository/DeckNameEditPopupBackgroundRepositoryImpl";
+import {DeckNameEditInputContainerRepositoryImpl} from "../../deck_name_edit_input_container/repository/DeckNameEditInputContainerRepositoryImpl";
+
 export class DeckNameEditPopupButtonsClickDetectServiceImpl implements DeckNameEditPopupButtonsClickDetectService {
     private static instance: DeckNameEditPopupButtonsClickDetectServiceImpl | null = null;
     private cameraRepository: CameraRepository;
     private deckNameEditPopupButtonsClickDetectRepository: DeckNameEditPopupButtonsClickDetectRepositoryImpl;
     private deckNameEditPopupButtonsRepository: DeckNameEditPopupButtonsRepositoryImpl;
+    private transparentBackgroundRepository: TransparentBackgroundRepositoryImpl;
+    private deckNameEditPopupBackgroundRepository: DeckNameEditPopupBackgroundRepositoryImpl;
+    private deckNameEditInputContainerRepository: DeckNameEditInputContainerRepositoryImpl;
 
     private constructor(private camera: THREE.Camera, private scene: THREE.Scene) {
         this.cameraRepository = CameraRepositoryImpl.getInstance();
         this.deckNameEditPopupButtonsClickDetectRepository = DeckNameEditPopupButtonsClickDetectRepositoryImpl.getInstance();
         this.deckNameEditPopupButtonsRepository = DeckNameEditPopupButtonsRepositoryImpl.getInstance();
+        this.transparentBackgroundRepository = TransparentBackgroundRepositoryImpl.getInstance();
+        this.deckNameEditPopupBackgroundRepository = DeckNameEditPopupBackgroundRepositoryImpl.getInstance();
+        this.deckNameEditInputContainerRepository = DeckNameEditInputContainerRepositoryImpl.getInstance();
     }
 
     static getInstance(camera: THREE.Camera, scene: THREE.Scene): DeckNameEditPopupButtonsClickDetectServiceImpl {
@@ -47,6 +57,16 @@ export class DeckNameEditPopupButtonsClickDetectServiceImpl implements DeckNameE
 
         if (clickedDeckNameEditPopupButton) {
             console.log(`Clicked Deck Make Pop-up Button ID: ${clickedDeckNameEditPopupButton.id}`);
+            this.setTransparentBackgroundVisibility(false);
+            this.setDeckNameEditPopupBackgroundVisibility(false);
+            this.setDeckNameEditPopupButtonsVisibility(false);
+            this.setDeckNameEditInputContainerVisibility('none');
+
+            const deckNameInputText = this.deckNameEditInputContainerRepository.findInputValue();
+            if (deckNameInputText !== null && deckNameInputText.length > 0) {
+                this.deckNameEditInputContainerRepository.clearUserInput();
+                this.deckNameEditInputContainerRepository.deleteUserInput();
+            }
 
             if (clickedDeckNameEditPopupButton.id === 0) {
                 console.log(`[DeckNameEditPopupButton] click cancel button!`);
@@ -66,13 +86,45 @@ export class DeckNameEditPopupButtonsClickDetectServiceImpl implements DeckNameE
 
         if (event.button === 0) {
             const clickPoint = { x: event.clientX, y: event.clientY };
-            return await this.handleLeftClick(clickPoint);
+            const buttonClick =  await this.handleLeftClick(clickPoint);
+            if (buttonClick) {
+                this.setButtonClickEnabled(false);
+                return buttonClick;
+            }
         }
         return null;
     }
 
     private getAllDeckNameEditPopupButtons(): DeckNameEditPopupButtons[] {
         return this.deckNameEditPopupButtonsRepository.findAllButtons();
+    }
+
+    private setTransparentBackgroundVisibility(isVisible: boolean): void {
+        const background = this.transparentBackgroundRepository.findTransparentBackground();
+        if (background) {
+            background.setVisibility(isVisible);
+        }
+    }
+
+    private setDeckNameEditPopupBackgroundVisibility(isVisible: boolean): void {
+        const background = this.deckNameEditPopupBackgroundRepository.findPopupBackground();
+        if (background !== null) {
+            background.setVisibility(isVisible);
+        }
+    }
+
+    private setDeckNameEditPopupButtonsVisibility(isVisible: boolean): void {
+        const buttons = this.deckNameEditPopupButtonsRepository.findAllButtons();
+        for (const button of buttons) {
+            button.setVisibility(isVisible);
+        }
+    }
+
+    private setDeckNameEditInputContainerVisibility(isVisible: 'block' | 'none'): void {
+        const container = this.deckNameEditInputContainerRepository.findDeckNameEditInputContainer();
+        if (container !== null) {
+            container.setVisibility(isVisible);
+        }
     }
 
 }


### PR DESCRIPTION
- Transparent Background의 visible 숨김 처리
- 덱 이름 편집 팝업창의 요소(팝업창, 버튼, 입력창)들의 visible 숨김 처리
- 입력창에 입력했던 텍스트 제거
- 팝업창의 취소/완료 버튼 클릭 비활성화