### PR TITLE
feat: [이재림] ‘카드 개수 미충족 알림창’의 확인 버튼을 클릭 시 ‘선택한 카드 개수’ 객체 삭제 [ETWGL-424]

### DIFF
--- a/src/deck_card_search_input_enter_detect/service/DeckCardSearchInputEnterDetectServiceImpl.ts
+++ b/src/deck_card_search_input_enter_detect/service/DeckCardSearchInputEnterDetectServiceImpl.ts
@@ -923,7 +923,7 @@ export class DeckCardSearchInputEnterDetectServiceImpl implements DeckCardSearch
 
     // To-do: 일반 모드와 편집 모드 동시에 사용되는 중복 코드 정리 필요함
     private setInteractionStatesAfterPopupButtonShownInNormalMode(currentClickedDeckId: number): void {
-        this.setMyDeckAlertModalButtonClickEnabled(true);
+        this.setMyDeckAllAlertModalButtonClickEnabled(true);
         this.setAllMyDeckButtonClickEnabled(false);
         this.setAllDeckNameEditButtonClickEnabled(false);
         this.setDeckNameEditButtonClickEnabled(currentClickedDeckId, false);
@@ -936,7 +936,7 @@ export class DeckCardSearchInputEnterDetectServiceImpl implements DeckCardSearch
     }
 
     private setInteractionStatesAfterPopupButtonShownInDeckEditMode(currentClickedDeckId: number): void {
-        this.setMyDeckAlertModalButtonClickEnabled(true);
+        this.setMyDeckAllAlertModalButtonClickEnabled(true);
         this.setAllMyDeckButtonClickEnabled(false);
         this.setAllDeckNameEditButtonClickEnabled(false);
         this.setDeckNameEditButtonClickEnabled(currentClickedDeckId, false);
@@ -996,8 +996,9 @@ export class DeckCardSearchInputEnterDetectServiceImpl implements DeckCardSearch
         this.deckEditDoneButtonHoverDetectRepository.setButtonHoverEnabled(isEnabled);
     }
 
-    private setMyDeckAlertModalButtonClickEnabled(isEnabled: boolean): void {
-        this.myDeckAlertModalButtonDetectRepository.setButtonClickEnabled(isEnabled);
+    private setMyDeckAllAlertModalButtonClickEnabled(isEnabled: boolean): void {
+        this.myDeckAlertModalButtonDetectRepository.setAllButtonClickEnabled(isEnabled);
+        this.myDeckAlertModalButtonDetectRepository.setButtonClickEnabled(AlertModalButtonsType.UNMATCHED_CARD, isEnabled);
     }
 
     private showEmptyInputPopup(): void {

--- a/src/deck_edit_done_button_click_detect/service/DeckEditDoneButtonClickDetectServiceImpl.ts
+++ b/src/deck_edit_done_button_click_detect/service/DeckEditDoneButtonClickDetectServiceImpl.ts
@@ -382,7 +382,8 @@ export class DeckEditDoneButtonClickDetectServiceImpl implements DeckEditDoneBut
     }
 
     private setIncompleteDeckPopupButtonClickEnabled(isEnabled: boolean): void {
-        this.myDeckAlertModalButtonsClickDetectRepository.setButtonClickEnabled(isEnabled);
+        this.myDeckAlertModalButtonsClickDetectRepository.setAllButtonClickEnabled(isEnabled);
+        this.myDeckAlertModalButtonsClickDetectRepository.setButtonClickEnabled(AlertModalButtonsType.INCOMPLETE_DECK, isEnabled);
     }
 
     private setAllMyDeckButtonClickEnabled(isEnabled: boolean): void {

--- a/src/my_deck_alert_modal_buttons_click_detect/repository/MyDeckAlertModalButtonsClickDetectRepositoryImpl.ts
+++ b/src/my_deck_alert_modal_buttons_click_detect/repository/MyDeckAlertModalButtonsClickDetectRepositoryImpl.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 
 import {MyDeckAlertModalButtonsClickDetectRepository} from "./MyDeckAlertModalButtonsClickDetectRepository";
 import {AlertModalButtons} from "../../alert_modal_buttons/entity/AlertModalButtons";
+import {AlertModalButtonsType} from "../../alert_modal_buttons/entity/AlertModalButtonsType";
 
 export class MyDeckAlertModalButtonsClickDetectRepositoryImpl implements MyDeckAlertModalButtonsClickDetectRepository {
     private static instance: MyDeckAlertModalButtonsClickDetectRepositoryImpl;
@@ -9,6 +10,7 @@ export class MyDeckAlertModalButtonsClickDetectRepositoryImpl implements MyDeckA
 
     private currentClickedButton: AlertModalButtons | null = null;
     private buttonClickEnabled: boolean = false;
+    private buttonClickEnabledMap: Map<AlertModalButtonsType, boolean> = new Map();
 
     public static getInstance(): MyDeckAlertModalButtonsClickDetectRepositoryImpl {
         if (!MyDeckAlertModalButtonsClickDetectRepositoryImpl.instance) {
@@ -59,12 +61,20 @@ export class MyDeckAlertModalButtonsClickDetectRepositoryImpl implements MyDeckA
         this.currentClickedButton = null;
     }
 
-    public setButtonClickEnabled(isEnabled: boolean): void {
+    public setAllButtonClickEnabled(isEnabled: boolean): void {
         this.buttonClickEnabled = isEnabled;
     }
 
-    public isButtonClickEnabled(): boolean {
+    public isAllButtonClickEnabled(): boolean {
         return this.buttonClickEnabled;
+    }
+
+    public setButtonClickEnabled(type: AlertModalButtonsType, isEnabled: boolean): void {
+        this.buttonClickEnabledMap.set(type, isEnabled);
+    }
+
+    public isButtonClickEnabled(type: AlertModalButtonsType): boolean | undefined {
+        return this.buttonClickEnabledMap.get(type);
     }
 
 }

--- a/src/my_deck_alert_modal_buttons_click_detect/service/MyDeckAlertModalButtonsClickDetectServiceImpl.ts
+++ b/src/my_deck_alert_modal_buttons_click_detect/service/MyDeckAlertModalButtonsClickDetectServiceImpl.ts
@@ -15,6 +15,7 @@ import {TransparentBackgroundRepositoryImpl} from "../../transparent_background/
 import {AlertModalContainerRepositoryImpl} from "../../alert_modal_container/repository/AlertModalContainerRepositoryImpl";
 import {MyDeckSearchInputContainerRepositoryImpl} from "../../my_deck_search_input_container/repository/MyDeckSearchInputContainerRepositoryImpl";
 import {MyDeckCardSearchCancelButtonRepositoryImpl} from "../../my_deck_card_search_cancel_button/repository/MyDeckCardSearchCancelButtonRepositoryImpl";
+import {AlertModalSelectedDeckCardCountRepositoryImpl} from "../../alert_modal_selected_deck_card_count/repository/AlertModalSelectedDeckCardCountRepositoryImpl";
 
 import {DeckEditButtonClickDetectRepositoryImpl} from "../../deck_edit_button_click_detect/repository/DeckEditButtonClickDetectRepositoryImpl";
 import {MyDeckButtonClickDetectRepositoryImpl} from "../../deck_button_click_detect/repository/MyDeckButtonClickDetectRepositoryImpl";
@@ -37,6 +38,7 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
     private alertModalContainerRepository: AlertModalContainerRepositoryImpl;
     private myDeckSearchInputContainerRepository: MyDeckSearchInputContainerRepositoryImpl;
     private myDeckCardSearchCancelButtonRepository: MyDeckCardSearchCancelButtonRepositoryImpl;
+    private alertModalSelectedDeckCardCountRepository: AlertModalSelectedDeckCardCountRepositoryImpl;
 
     private deckEditButtonClickDetectRepository: DeckEditButtonClickDetectRepositoryImpl;
     private myDeckButtonClickDetectRepository: MyDeckButtonClickDetectRepositoryImpl;
@@ -58,6 +60,7 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
         this.alertModalContainerRepository = AlertModalContainerRepositoryImpl.getInstance(scene);
         this.myDeckSearchInputContainerRepository = MyDeckSearchInputContainerRepositoryImpl.getInstance();
         this.myDeckCardSearchCancelButtonRepository = MyDeckCardSearchCancelButtonRepositoryImpl.getInstance();
+        this.alertModalSelectedDeckCardCountRepository = AlertModalSelectedDeckCardCountRepositoryImpl.getInstance(scene);
 
         this.deckEditButtonClickDetectRepository = DeckEditButtonClickDetectRepositoryImpl.getInstance();
         this.myDeckButtonClickDetectRepository = MyDeckButtonClickDetectRepositoryImpl.getInstance();
@@ -89,12 +92,16 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
         );
 
         if (clickedAlertModalButton) {
-            if (clickedAlertModalButton.type === AlertModalButtonsType.UNMATCHED_CARD) {
+            if (clickedAlertModalButton.type === AlertModalButtonsType.UNMATCHED_CARD &&
+                this.isButtonClickEnabled(AlertModalButtonsType.UNMATCHED_CARD)
+            ) {
                 console.log(`[DEBUG] Click Alert Modal Button Type: UNMATCHED_CARD`);
                 this.handleNotFoundCardPopupButtonClick();
             }
 
-            if (clickedAlertModalButton.type === AlertModalButtonsType.INCOMPLETE_DECK) {
+            if (clickedAlertModalButton.type === AlertModalButtonsType.INCOMPLETE_DECK &&
+                this.isButtonClickEnabled(AlertModalButtonsType.INCOMPLETE_DECK)
+            ) {
                 console.log(`[DEBUG] Click Alert Modal Button Type: INCOMPLETE_DECK`);
                 this.handleIncompleteDeckPopupButtonClick();
             }
@@ -106,13 +113,13 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
     }
 
     public async onMouseDown(event: MouseEvent): Promise<AlertModalButtons | null> {
-        if (!this.isButtonClickEnabled()) return null;
+        if (!this.isAllButtonClickEnabled()) return null;
 
         if (event.button === 0) {
             const clickPoint = { x: event.clientX, y: event.clientY };
             const result  = await this.handleButtonClick(clickPoint);
             if (result) {
-                this.setButtonClickEnabled(false);
+                this.setAllButtonClickEnabled(false);
             }
             return result;
         }
@@ -130,17 +137,26 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
 
     private handleIncompleteDeckPopupButtonClick(): void {
         this.hideIncompleteDeckPopup();
+        this.deleteAlertModalSelectedDeckCardCount();
 
         const currentClickedDeckId = this.getCurrentClickDeckId()!;
         this.setInteractionAfterIncompleteDeckPopupButtonClick(currentClickedDeckId);
     }
 
-    private setButtonClickEnabled(isEnabled: boolean): void {
-        this.myDeckAlertModalButtonsClickDetectRepository.setButtonClickEnabled(isEnabled);
+    private setAllButtonClickEnabled(isEnabled: boolean): void {
+        this.myDeckAlertModalButtonsClickDetectRepository.setAllButtonClickEnabled(isEnabled);
     }
 
-    private isButtonClickEnabled(): boolean {
-        return this.myDeckAlertModalButtonsClickDetectRepository.isButtonClickEnabled();
+    private isAllButtonClickEnabled(): boolean {
+        return this.myDeckAlertModalButtonsClickDetectRepository.isAllButtonClickEnabled();
+    }
+
+    private setButtonClickEnabled(type: AlertModalButtonsType, isEnabled: boolean): void {
+        this.myDeckAlertModalButtonsClickDetectRepository.setButtonClickEnabled(type, isEnabled);
+    }
+
+    private isButtonClickEnabled(type: AlertModalButtonsType): boolean | undefined {
+        return this.myDeckAlertModalButtonsClickDetectRepository.isButtonClickEnabled(type);
     }
 
     private getAllAlertModalButtons(): AlertModalButtons[] {
@@ -187,6 +203,10 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
         this.alertModalButtonsRepository.findButtonByType(AlertModalButtonsType.INCOMPLETE_DECK)?.setVisibility(isVisible);
     }
 
+    private deleteAlertModalSelectedDeckCardCount(): void {
+        this.alertModalSelectedDeckCardCountRepository.deleteSelectedDeckCardCount();
+    }
+
     private hideDeckCardSearchCancelButton(): void {
         this.myDeckCardSearchCancelButtonRepository.findButton()?.setVisibility(false);
     }
@@ -206,6 +226,7 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
         this.setBuildDeckButtonClickEnabled(true);
         this.setAllDeckDeleteButtonClickEnabled(true);
         this.setMyDeckCardSearchInputEnabled(false);
+        this.setButtonClickEnabled(AlertModalButtonsType.UNMATCHED_CARD, false);
 
         if (this.isDeckEditMode() == true) {
             this.setMyDeckBlockHoverEnabled(true);
@@ -228,6 +249,7 @@ export class MyDeckAlertModalButtonsClickDetectServiceImpl implements MyDeckAler
         this.setCardDeleteButtonClickEnabled(false);
         this.setCardAddButtonClickEnabled(false);
         this.setMyDeckCardSearchInputEnabled(false);
+        this.setButtonClickEnabled(AlertModalButtonsType.INCOMPLETE_DECK, false);
     }
 
     private setAllMyDeckButtonClickEnabled(isEnabled: boolean): void {

--- a/test/refactor_draw_my_deck/refactor_draw_my_deck.ts
+++ b/test/refactor_draw_my_deck/refactor_draw_my_deck.ts
@@ -400,7 +400,7 @@ export class TCGJustTestMyDeckView {
                 this.reAddMyDeckNameText();
             }
         }, false);
-        this.renderer.domElement.addEventListener('mousedown', (e) => this.myDeckAlertModalButtonsClickDetectService.onMouseDown(e), false);
+        this.renderer.domElement.addEventListener('mousedown', async (e) => await this.myDeckAlertModalButtonsClickDetectService.onMouseDown(e), false);
     }
 
     public static getInstance(simulationMyDeckContainer: HTMLElement): TCGJustTestMyDeckView {


### PR DESCRIPTION
- 알림창의 확인 버튼 클릭 시 배치된 사용자가 선택한 현재 카드 개수 객체 삭제
- alert modal 알림창의 확인 버튼들의 이벤트 중복 문제 수정