### PR TITLE
feat: [EDDI] 입력/드래그를 제외한 채 draw_your_field_efr 에 핸드 카드 렌더링을 EFR 구조로 메시 생성, 좌표 계산 작업의 책임 분리 [ETWGL-3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "draw-entity-frame-renderer": "webpack serve --config ./test/draw_entity_frame_renderer/config/webpack.dev.js",
     "draw-simple-efr": "webpack serve --config ./test/draw_simple_efr/config/webpack.dev.js",
     "draw-efr-my-deck": "webpack serve --config ./test/draw_efr_my_deck/config/webpack.dev.js",
-    "draw-your-field-efr": "webpack serve --config ./test/draw_your_field_efr/config/webpack.dev.js"
+    "draw-your-field-efr": "webpack serve --config ./test/draw_your_field_efr/config/webpack.dev.js",
+    "draw-your-field-with-hand-efr": "webpack serve --config ./test/draw_your_field_with_hand_efr/config/webpack.dev.js"
   }
 }

--- a/src/battle_field_hand/entity/HandCard.ts
+++ b/src/battle_field_hand/entity/HandCard.ts
@@ -1,0 +1,19 @@
+import { CardJob } from "../../card/job";
+import { CardKind } from "../../card/kind";
+
+// Pure data entity for an E+F+R-rendered hand card.
+// Populated by looking up getCardById(cardId) in the scenario wiring, so the Renderer stays
+// decoupled from the CSV/every_card_info data source.
+//
+// energyCount: currently-attached energy for a UNIT card. When 0, the Renderer skips both
+// the energy icon and the number text — per user directive, "show 0" is not a valid state.
+export interface HandCard {
+    readonly cardId: number;
+    readonly cardKind: CardKind;
+    readonly unitJob: CardJob;
+    readonly raceId: number;
+    readonly hpId: number | null;
+    readonly attackPowerId: number;
+    readonly kindId: number;
+    readonly energyCount: number;
+}

--- a/src/battle_field_hand/entity/HandCardData.ts
+++ b/src/battle_field_hand/entity/HandCardData.ts
@@ -1,0 +1,23 @@
+import { CardKind } from "../../card/kind";
+import { CardJob } from "../../card/job";
+
+// Pure-data view of one hand card. Resolved upfront from getCardById(cardId) so
+// the renderer never touches the card DB or texture manager directly.
+//
+// Field semantics mirror the Korean-keyed Card interface:
+//   cardTextureId  ← card.카드번호   (main card image)
+//   raceId         ← Number(card.종족)
+//   hpId           ← card.체력        (may be null for some non-unit cards)
+//   attackPowerId  ← card.공격력      (weapon / staff / dagger texture id)
+//   kindId         ← Number(card.종류) (card_kinds image id, for non-UNIT cards)
+//   cardKind       ← parseInt(card.종류) as CardKind
+//   unitJob        ← parseInt(card.병종) as CardJob
+export interface HandCardData {
+    readonly cardTextureId: number;
+    readonly raceId: number;
+    readonly hpId: number | null;
+    readonly attackPowerId: number;
+    readonly kindId: number;
+    readonly cardKind: CardKind;
+    readonly unitJob: CardJob;
+}

--- a/src/battle_field_hand/frame/BattleFieldHandLayoutFrame.ts
+++ b/src/battle_field_hand/frame/BattleFieldHandLayoutFrame.ts
@@ -1,0 +1,39 @@
+// Hand row layout. Mirrors BattleFieldHandServiceImpl.calculateHandPosition:
+//   handX = (startXRatio + cardIndex * cardGapRatio) * innerWidth
+//   handY = baselineYHeightRatio * innerHeight + baselineYWidthOffsetRatio * innerWidth
+//
+// Note: Y is a MIX of innerHeight and innerWidth terms — baselineYHeightRatio scales with innerHeight,
+// but the +half-card offset scales with innerWidth (because cardHeight itself is derived from innerWidth).
+
+export interface BattleFieldHandLayoutFrame {
+    readonly startXRatio: number;
+    readonly baselineYHeightRatio: number;
+    readonly baselineYWidthOffsetRatio: number;
+    readonly cardGapRatio: number;
+}
+
+export function createDefaultBattleFieldHandLayoutFrame(): BattleFieldHandLayoutFrame {
+    const HALF = 0.5;
+    const HAND_X_CRITERIA = 0.357904;
+    const HAND_Y_CRITERIA = 1.052107;
+    const CARD_WIDTH_RATIO = 0.06493506493;
+    const CARD_HEIGHT_RATIO = CARD_WIDTH_RATIO * 1.615;
+
+    return {
+        startXRatio: HAND_X_CRITERIA - HALF,             // -0.142096
+        baselineYHeightRatio: HALF - HAND_Y_CRITERIA,    // -0.552107
+        baselineYWidthOffsetRatio: CARD_HEIGHT_RATIO * HALF,
+        cardGapRatio: 0.094696,
+    };
+}
+
+export function computeHandCardCenter(
+    layout: BattleFieldHandLayoutFrame,
+    cardIndex: number,
+    viewportWidth: number,
+    viewportHeight: number,
+): { x: number; y: number } {
+    const x = (layout.startXRatio + cardIndex * layout.cardGapRatio) * viewportWidth;
+    const y = layout.baselineYHeightRatio * viewportHeight + layout.baselineYWidthOffsetRatio * viewportWidth;
+    return { x, y };
+}

--- a/src/battle_field_hand/frame/HandCardFrame.ts
+++ b/src/battle_field_hand/frame/HandCardFrame.ts
@@ -1,0 +1,46 @@
+// Per-card frame for hand rendering. All offsets are proportional to the card's own width/height:
+//   cardWidth  = cardWidthRatio * window.innerWidth
+//   cardHeight = cardWidth * cardAspect
+//   slot X      = offsetXRatio * cardWidth   (from the card's local origin = card center)
+//   slot Y      = offsetYRatio * cardHeight
+//   slot width  = widthRatio * cardWidth
+//   slot height = slot width * slot.aspect
+//
+// These match BattleFieldHandServiceImpl.calculate*Position / create*Mesh exactly.
+// Staff aspect/offset differ from weapon, so a staff-cast MAGICIAN looks identical to the legacy path.
+
+export interface HandCardSlot {
+    readonly widthRatio: number;
+    readonly aspect: number;
+    readonly offsetXRatio: number;
+    readonly offsetYRatio: number;
+    readonly renderOrder: number;
+}
+
+export interface HandCardFrame {
+    readonly cardWidthRatio: number;
+    readonly cardAspect: number;
+    readonly slots: {
+        readonly weapon: HandCardSlot;
+        readonly staff: HandCardSlot;
+        readonly kinds: HandCardSlot;
+        readonly race: HandCardSlot;
+        readonly hp: HandCardSlot;
+        readonly energy: HandCardSlot;
+    };
+}
+
+export function createDefaultHandCardFrame(): HandCardFrame {
+    return {
+        cardWidthRatio: 0.06493506493,
+        cardAspect: 1.615,
+        slots: {
+            weapon: { widthRatio: 0.63, aspect: 1.651,    offsetXRatio:  0.44, offsetYRatio: -0.45666, renderOrder: 2 },
+            staff:  { widthRatio: 0.63, aspect: 1.9353,   offsetXRatio:  0.54, offsetYRatio: -0.30666, renderOrder: 2 },
+            kinds:  { widthRatio: 0.4,  aspect: 1,        offsetXRatio:  0.5,  offsetYRatio: -0.5,     renderOrder: 2 },
+            race:   { widthRatio: 0.4,  aspect: 1,        offsetXRatio:  0.5,  offsetYRatio:  0.5,     renderOrder: 2 },
+            hp:     { widthRatio: 0.31, aspect: 1.65454,  offsetXRatio: -0.5,  offsetYRatio: -0.43438, renderOrder: 2 },
+            energy: { widthRatio: 0.39, aspect: 1.344907, offsetXRatio: -0.5,  offsetYRatio:  0.5,     renderOrder: 2 },
+        },
+    };
+}

--- a/src/battle_field_hand/renderer/BattleFieldHandRendererV2.ts
+++ b/src/battle_field_hand/renderer/BattleFieldHandRendererV2.ts
@@ -1,0 +1,75 @@
+import * as THREE from "three";
+
+import { HandCard } from "../entity/HandCard";
+import { HandCardFrame } from "../frame/HandCardFrame";
+import {
+    BattleFieldHandLayoutFrame,
+    computeHandCardCenter,
+} from "../frame/BattleFieldHandLayoutFrame";
+import { HandCardRendererV2 } from "./HandCardRendererV2";
+
+interface HandEntry {
+    card: HandCard;
+    cardIndex: number;
+    group: THREE.Group;
+}
+
+interface HandUserData {
+    entries: HandEntry[];
+}
+
+// Composes per-card Groups along a row. The outer Group is positioned at world origin;
+// each child Group is positioned at its computed hand-slot center.
+export class BattleFieldHandRendererV2 {
+    constructor(private readonly cardRenderer: HandCardRendererV2 = new HandCardRendererV2()) {}
+
+    public async build(
+        hand: readonly HandCard[],
+        cardFrame: HandCardFrame,
+        layout: BattleFieldHandLayoutFrame,
+    ): Promise<THREE.Group> {
+        const handGroup = new THREE.Group();
+        const entries: HandEntry[] = [];
+
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+
+        for (let cardIndex = 0; cardIndex < hand.length; cardIndex++) {
+            const card = hand[cardIndex];
+            const cardGroup = await this.cardRenderer.build(card, cardFrame);
+
+            const { x, y } = computeHandCardCenter(layout, cardIndex, w, h);
+            cardGroup.position.set(x, y, 0);
+
+            handGroup.add(cardGroup);
+            entries.push({ card, cardIndex, group: cardGroup });
+        }
+
+        const userData: HandUserData = { entries };
+        handGroup.userData = userData;
+        return handGroup;
+    }
+
+    public resize(
+        cardFrame: HandCardFrame,
+        layout: BattleFieldHandLayoutFrame,
+        handGroup: THREE.Group,
+        viewportWidth: number,
+        viewportHeight: number,
+    ): void {
+        const { entries } = handGroup.userData as HandUserData;
+        for (const entry of entries) {
+            const { x, y } = computeHandCardCenter(layout, entry.cardIndex, viewportWidth, viewportHeight);
+            entry.group.position.set(x, y, 0);
+            this.cardRenderer.resize(cardFrame, entry.group);
+        }
+    }
+
+    public dispose(handGroup: THREE.Group): void {
+        const { entries } = handGroup.userData as HandUserData;
+        for (const entry of entries) {
+            this.cardRenderer.dispose(entry.group);
+        }
+        handGroup.clear();
+    }
+}

--- a/src/battle_field_hand/renderer/HandCardRendererV2.ts
+++ b/src/battle_field_hand/renderer/HandCardRendererV2.ts
@@ -1,0 +1,193 @@
+import * as THREE from "three";
+
+import { CardJob } from "../../card/job";
+import { CardKind } from "../../card/kind";
+import { Vector2d } from "../../common/math/Vector2d";
+import { HandCard } from "../entity/HandCard";
+import { HandCardFrame, HandCardSlot } from "../frame/HandCardFrame";
+
+interface HandCardUserData {
+    baseCardWidth: number;
+    baseCardHeight: number;
+}
+
+interface SlotBuild {
+    slot: HandCardSlot;
+    imageSrc: string;
+}
+
+const RESOURCE_PATHS = {
+    card: (id: number) => `resource/battle_field_unit/card/${id}.png`,
+    swordPower: (id: number) => `resource/battle_field_unit/sword_power/${id}.png`,
+    staffPower: (id: number) => `resource/battle_field_unit/staff_power/${id}.png`,
+    hp: (id: number) => `resource/battle_field_unit/hp/${id}.png`,
+    // Energy texture is name-based (non-numeric filename) in the resource tree.
+    energy: () => `resource/battle_field_unit/energy/unit_card_energy.png`,
+    race: (id: number) => `resource/card_race/${id}.png`,
+    cardKinds: (id: number) => `resource/card_kinds/${id}.png`,
+};
+
+// Renders one hand card (main card + conditional slots + optional energy-text) into a Group
+// centered at the local origin (0, 0). The parent BattleFieldHandRendererV2 places each card
+// into the row by setting the outer Group's position.
+export class HandCardRendererV2 {
+    public async build(entity: HandCard, frame: HandCardFrame): Promise<THREE.Group> {
+        const group = new THREE.Group();
+
+        const cardWidth = frame.cardWidthRatio * window.innerWidth;
+        const cardHeight = cardWidth * frame.cardAspect;
+
+        const cardTexture = await this.loadTexture(RESOURCE_PATHS.card(entity.cardId));
+        group.add(this.createMesh(cardTexture, cardWidth, cardHeight, new Vector2d(0, 0), 1));
+
+        const slotBuilds = this.resolveSlotBuilds(entity, frame);
+        for (const { slot, imageSrc } of slotBuilds) {
+            const slotWidth = slot.widthRatio * cardWidth;
+            const slotHeight = slotWidth * slot.aspect;
+            const position = new Vector2d(
+                slot.offsetXRatio * cardWidth,
+                slot.offsetYRatio * cardHeight,
+            );
+            const texture = await this.loadTexture(imageSrc);
+            group.add(this.createMesh(texture, slotWidth, slotHeight, position, slot.renderOrder));
+        }
+
+        // Energy text rides alongside the energy icon; both are gated on energyCount > 0 (see resolveSlotBuilds).
+        if (entity.cardKind === CardKind.UNIT && entity.energyCount > 0) {
+            const energySlot = frame.slots.energy;
+            const energyPos = new Vector2d(
+                energySlot.offsetXRatio * cardWidth,
+                energySlot.offsetYRatio * cardHeight,
+            );
+            const textScale = frame.cardWidthRatio * 0.2 * window.innerWidth;
+            group.add(this.createEnergyTextMesh(entity.energyCount, energyPos, textScale));
+        }
+
+        const userData: HandCardUserData = { baseCardWidth: cardWidth, baseCardHeight: cardHeight };
+        group.userData = userData;
+        return group;
+    }
+
+    // Viewport-driven rescale: uniform scale on the Group propagates to every child mesh's
+    // size AND position, because all slot positions are expressed as ratios of cardWidth/cardHeight.
+    public resize(frame: HandCardFrame, group: THREE.Group): void {
+        const userData = group.userData as HandCardUserData;
+        const newCardWidth = frame.cardWidthRatio * window.innerWidth;
+        const newCardHeight = newCardWidth * frame.cardAspect;
+        const sx = newCardWidth / userData.baseCardWidth;
+        const sy = newCardHeight / userData.baseCardHeight;
+        group.scale.set(sx, sy, 1);
+    }
+
+    public dispose(group: THREE.Group): void {
+        group.traverse((object) => {
+            if (object instanceof THREE.Mesh) {
+                object.geometry?.dispose();
+                const material = object.material;
+                if (Array.isArray(material)) {
+                    material.forEach((m) => m.dispose());
+                } else {
+                    material?.dispose();
+                }
+            }
+        });
+        group.clear();
+    }
+
+    private resolveSlotBuilds(entity: HandCard, frame: HandCardFrame): SlotBuild[] {
+        const builds: SlotBuild[] = [];
+
+        // Matches BattleFieldHandServiceImpl.addAttributesToCardGroup exactly:
+        //   WARRIOR → weapon, MAGICIAN → staff, ASSASSIN → (nothing, same as legacy gap)
+        //   non-UNIT → kinds
+        if (entity.cardKind === CardKind.UNIT) {
+            if (entity.unitJob === CardJob.WARRIOR) {
+                builds.push({ slot: frame.slots.weapon, imageSrc: RESOURCE_PATHS.swordPower(entity.attackPowerId) });
+            } else if (entity.unitJob === CardJob.MAGICIAN) {
+                builds.push({ slot: frame.slots.staff, imageSrc: RESOURCE_PATHS.staffPower(entity.attackPowerId) });
+            }
+        } else {
+            builds.push({ slot: frame.slots.kinds, imageSrc: RESOURCE_PATHS.cardKinds(entity.kindId) });
+        }
+
+        if (entity.raceId >= 0) {
+            builds.push({ slot: frame.slots.race, imageSrc: RESOURCE_PATHS.race(entity.raceId) });
+        }
+
+        if (entity.hpId != null && entity.hpId >= 0) {
+            builds.push({ slot: frame.slots.hp, imageSrc: RESOURCE_PATHS.hp(entity.hpId) });
+        }
+
+        // Skip the energy icon entirely when attached energy is 0 — drawing an empty "E" with "0"
+        // is considered visual noise, not "displaying a count of zero".
+        if (entity.cardKind === CardKind.UNIT && entity.energyCount > 0) {
+            builds.push({ slot: frame.slots.energy, imageSrc: RESOURCE_PATHS.energy() });
+        }
+
+        return builds;
+    }
+
+    // Mirrors BattleFieldHandServiceImpl.createEnergyTextMesh to preserve the legacy "0" glyph.
+    private createEnergyTextMesh(value: number, position: Vector2d, baseScale: number): THREE.Mesh {
+        const canvas = document.createElement("canvas");
+        canvas.width = 128;
+        canvas.height = 128;
+        const ctx = canvas.getContext("2d")!;
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = "white";
+        ctx.font = "bold 96px Arial";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+
+        const yOffset = canvas.height / 2 + 0.01030927835 * window.innerHeight;
+        ctx.fillText(value.toString(), canvas.width / 2, yOffset);
+
+        const texture = new THREE.CanvasTexture(canvas);
+        texture.needsUpdate = true;
+
+        const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true });
+        const geometry = new THREE.PlaneGeometry(1, 1);
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.position.set(position.getX(), position.getY(), 0.01);
+        mesh.scale.set(baseScale, baseScale, 1);
+        return mesh;
+    }
+
+    // SRGB + LinearFilter + no mipmaps — match the unit/card texture baseline.
+    private loadTexture(imageSrc: string): Promise<THREE.Texture> {
+        return new Promise((resolve, reject) => {
+            new THREE.TextureLoader().load(
+                imageSrc,
+                (texture) => {
+                    texture.colorSpace = THREE.SRGBColorSpace;
+                    texture.magFilter = THREE.LinearFilter;
+                    texture.minFilter = THREE.LinearFilter;
+                    texture.generateMipmaps = false;
+                    resolve(texture);
+                },
+                undefined,
+                (error) => reject(error),
+            );
+        });
+    }
+
+    private createMesh(
+        texture: THREE.Texture,
+        width: number,
+        height: number,
+        position: Vector2d,
+        renderOrder: number,
+    ): THREE.Mesh {
+        const material = new THREE.MeshBasicMaterial({
+            map: texture,
+            transparent: true,
+            opacity: 1,
+        });
+        const geometry = new THREE.PlaneGeometry(width, height);
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.renderOrder = renderOrder;
+        mesh.position.set(position.getX(), position.getY(), 0);
+        return mesh;
+    }
+}

--- a/test/draw_your_field_with_hand_efr/config/webpack.common.js
+++ b/test/draw_your_field_with_hand_efr/config/webpack.common.js
@@ -1,0 +1,42 @@
+const path = require("path");
+
+module.exports = {
+    entry: {
+        draw_your_field_with_hand_efr: "./test/draw_your_field_with_hand_efr/draw_your_field_with_hand_efr.ts",
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.(png|jpg|gif)$/i,
+                type: 'asset/resource',
+            },
+            {
+                test: /\.json$/,
+                type: 'json',
+            },
+            {
+                test: /\.mp3$/,
+                use: 'file-loader',
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".tsx", ".ts", ".js"],
+        alias: {
+            '@resource': path.resolve(__dirname, '../../../resource'),
+        },
+        fallback: {
+            "fs": false,
+            "path": false,
+        },
+    },
+    output: {
+        filename: "bundle.js",
+        path: path.resolve(__dirname, "../../dist/draw_your_field_with_hand_efr"),
+    },
+};

--- a/test/draw_your_field_with_hand_efr/config/webpack.dev.js
+++ b/test/draw_your_field_with_hand_efr/config/webpack.dev.js
@@ -1,0 +1,17 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+const path = require("path");
+
+module.exports = merge(common, {
+    mode: "development",
+    devtool: "eval-source-map",
+    devServer: {
+        static: [
+            { directory: path.join(__dirname, "../") },
+            { directory: path.join(__dirname, "../../../") },
+            { directory: path.join(__dirname, "../../../resource") },
+        ],
+        hot: true,
+        historyApiFallback: true,
+    },
+});

--- a/test/draw_your_field_with_hand_efr/draw_your_field_with_hand_efr.ts
+++ b/test/draw_your_field_with_hand_efr/draw_your_field_with_hand_efr.ts
@@ -1,0 +1,97 @@
+import { CameraManager } from "../../src/core/camera/CameraManager";
+import { RendererManager } from "../../src/core/renderer/RendererManager";
+import { SceneManager } from "../../src/core/scene/SceneManager";
+import { AnimationLoop } from "../../src/core/animation/AnimationLoop";
+
+import { createBattleFieldBackgroundFrame } from "../../src/background/frame/BackgroundFrame";
+import { BackgroundRendererV2 } from "../../src/background/renderer/BackgroundRendererV2";
+
+import { createDefaultYourFieldAreaFrame } from "../../src/your_field_area/frame/YourFieldAreaFrame";
+import { YourFieldAreaRendererV2 } from "../../src/your_field_area/renderer/YourFieldAreaRendererV2";
+
+import { BattleFieldHandMapRepositoryImpl } from "../../src/battle_field_hand/repository/BattleFieldHandMapRepositoryImpl";
+import { HandCard } from "../../src/battle_field_hand/entity/HandCard";
+import { createDefaultHandCardFrame } from "../../src/battle_field_hand/frame/HandCardFrame";
+import { createDefaultBattleFieldHandLayoutFrame } from "../../src/battle_field_hand/frame/BattleFieldHandLayoutFrame";
+import { BattleFieldHandRendererV2 } from "../../src/battle_field_hand/renderer/BattleFieldHandRendererV2";
+
+import { getCardById } from "../../src/card/utility";
+import { CardJob } from "../../src/card/job";
+import { CardKind } from "../../src/card/kind";
+
+const rootElement = document.getElementById('app');
+if (!rootElement) {
+    throw new Error("Cannot find element with id 'app'.");
+}
+
+function resolveHandCards(cardIds: number[]): HandCard[] {
+    const hand: HandCard[] = [];
+    for (const cardId of cardIds) {
+        const card = getCardById(cardId);
+        if (!card) {
+            console.warn(`Card ${cardId} not found in every_card_info — skipping.`);
+            continue;
+        }
+        hand.push({
+            cardId,
+            cardKind: parseInt(card.종류, 10) as CardKind,
+            unitJob: parseInt(card.병종, 10) as CardJob,
+            raceId: parseInt(card.종족, 10),
+            hpId: card.체력,
+            attackPowerId: card.공격력,
+            kindId: parseInt(card.종류, 10),
+            // No real energy-attachment data source in the pilot; default to 0 so the Renderer
+            // skips the energy icon + number (see feedback_zero_value_visuals memory).
+            energyCount: 0,
+        });
+    }
+    return hand;
+}
+
+async function main(container: HTMLElement): Promise<void> {
+    const rendererManager = new RendererManager(container);
+    const sceneManager = new SceneManager();
+    const cameraManager = CameraManager.getInstance();
+
+    const aspectRatio = window.innerWidth / window.innerHeight;
+    const viewSize = window.innerHeight;
+    cameraManager.createAndSetActiveCamera(aspectRatio, viewSize);
+
+    const scene = sceneManager.createScene('draw-your-field-with-hand-efr');
+
+    const backgroundFrame = createBattleFieldBackgroundFrame();
+    const backgroundRenderer = new BackgroundRendererV2();
+    const backgroundGroup = await backgroundRenderer.build(backgroundFrame);
+    scene.add(backgroundGroup);
+
+    const yourFieldAreaFrame = createDefaultYourFieldAreaFrame();
+    const yourFieldAreaRenderer = new YourFieldAreaRendererV2();
+    const yourFieldAreaGroup = await yourFieldAreaRenderer.build(yourFieldAreaFrame);
+    scene.add(yourFieldAreaGroup);
+
+    const handCardIds = BattleFieldHandMapRepositoryImpl.getInstance().getBattleFieldHandList();
+    const hand = resolveHandCards(handCardIds);
+
+    const handCardFrame = createDefaultHandCardFrame();
+    const handLayoutFrame = createDefaultBattleFieldHandLayoutFrame();
+    const handRenderer = new BattleFieldHandRendererV2();
+    const handGroup = await handRenderer.build(hand, handCardFrame, handLayoutFrame);
+    scene.add(handGroup);
+
+    const animationLoop = new AnimationLoop(rendererManager, sceneManager, cameraManager);
+    animationLoop.start();
+
+    window.addEventListener('resize', () => {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        cameraManager.updateAspect(width, height);
+        rendererManager.resize(width, height);
+        backgroundRenderer.resize(backgroundFrame, backgroundGroup, width, height);
+        yourFieldAreaRenderer.resize(yourFieldAreaFrame, yourFieldAreaGroup, width, height);
+        handRenderer.resize(handCardFrame, handLayoutFrame, handGroup, width, height);
+    });
+}
+
+main(rootElement).catch((error) => {
+    console.error('draw_your_field_with_hand_efr failed to start:', error);
+});

--- a/test/draw_your_field_with_hand_efr/index.html
+++ b/test/draw_your_field_with_hand_efr/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EDDI TCG — draw_your_field_with_hand_efr</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+            background: #111;
+        }
+        #app {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="app"></div>
+    <script type="module" src="bundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
feat: [EDDI] 입력/드래그를 제외한 채 draw_your_field_efr(배경 + 필드 영역)에 핸드 카드 렌더링을 EFR 구조로 메시 생성, 좌표 계산 작업의 책임 분리 [ETWGL-3]