### PR TITLE
feat: [EDDI] HTML DOM 오버레이를 EFR 패턴에 편입하여 showFieldEnergy / showFieldEnergyRace / showFieldEnergyCount 세 요소를 대상으로, 새로운 DomFrameRenderer 인터페이스를 도입해 DOM 렌더러의 build/update/dispose 구성 [ETWGL-5]

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "draw-simple-efr": "webpack serve --config ./test/draw_simple_efr/config/webpack.dev.js",
     "draw-efr-my-deck": "webpack serve --config ./test/draw_efr_my_deck/config/webpack.dev.js",
     "draw-your-field-efr": "webpack serve --config ./test/draw_your_field_efr/config/webpack.dev.js",
-    "draw-your-field-with-hand-efr": "webpack serve --config ./test/draw_your_field_with_hand_efr/config/webpack.dev.js"
+    "draw-your-field-with-hand-efr": "webpack serve --config ./test/draw_your_field_with_hand_efr/config/webpack.dev.js",
+    "draw-your-field-interactive-efr": "webpack serve --config ./test/draw_your_field_interactive_efr/config/webpack.dev.js",
+    "draw-field-energy-hud-efr": "webpack serve --config ./test/draw_field_energy_hud_efr/config/webpack.dev.js"
   }
 }

--- a/src/battle_field_hand/interaction/HandInteractionBridge.ts
+++ b/src/battle_field_hand/interaction/HandInteractionBridge.ts
@@ -1,0 +1,128 @@
+import * as THREE from "three";
+
+// Thin raycaster-based input bridge for E+F+R pilots. Walks up from a raycaster hit to find
+// the nearest ancestor Group with `userData.entityId` set by the Renderer. Reports entity IDs
+// (not mesh uuids) to the scenario callbacks, so domain state stays separated from Three.js.
+//
+// Intentionally independent of the legacy LeftClickDetectServiceImpl / DragMoveServiceImpl /
+// MouseDropServiceImpl — see project_legacy_input_services memory.
+
+export interface HandInteractionCallbacks {
+    onPickup?: (entityId: number, group: THREE.Group) => void;
+    onDrag?: (entityId: number, group: THREE.Group, worldX: number, worldY: number) => void;
+    onDrop?: (entityId: number, group: THREE.Group, worldX: number, worldY: number) => void;
+}
+
+export class HandInteractionBridge {
+    private readonly raycaster = new THREE.Raycaster();
+    private readonly dragPlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+
+    private activeEntityId: number | null = null;
+    private activeGroup: THREE.Group | null = null;
+    private readonly pickupOffset = new THREE.Vector2(0, 0);
+    private attached = false;
+
+    constructor(
+        private readonly domElement: HTMLElement,
+        private readonly camera: THREE.Camera,
+        private readonly scene: THREE.Scene,
+        private readonly callbacks: HandInteractionCallbacks,
+    ) {}
+
+    public attach(): void {
+        if (this.attached) return;
+        this.domElement.addEventListener('mousedown', this.onMouseDown);
+        this.domElement.addEventListener('mousemove', this.onMouseMove);
+        this.domElement.addEventListener('mouseup', this.onMouseUp);
+        this.attached = true;
+    }
+
+    public detach(): void {
+        if (!this.attached) return;
+        this.domElement.removeEventListener('mousedown', this.onMouseDown);
+        this.domElement.removeEventListener('mousemove', this.onMouseMove);
+        this.domElement.removeEventListener('mouseup', this.onMouseUp);
+        this.attached = false;
+    }
+
+    private onMouseDown = (event: MouseEvent): void => {
+        if (event.button !== 0) return;
+
+        const world = this.screenToWorld(event.clientX, event.clientY);
+        if (!world) return;
+
+        const pick = this.pickEntityGroup(event.clientX, event.clientY);
+        if (!pick) return;
+
+        this.activeEntityId = pick.entityId;
+        this.activeGroup = pick.group;
+        this.pickupOffset.set(
+            world.x - pick.group.position.x,
+            world.y - pick.group.position.y,
+        );
+
+        this.callbacks.onPickup?.(pick.entityId, pick.group);
+    };
+
+    private onMouseMove = (event: MouseEvent): void => {
+        if (this.activeEntityId === null || !this.activeGroup) return;
+        const world = this.screenToWorld(event.clientX, event.clientY);
+        if (!world) return;
+
+        const nextX = world.x - this.pickupOffset.x;
+        const nextY = world.y - this.pickupOffset.y;
+        this.activeGroup.position.set(nextX, nextY, this.activeGroup.position.z);
+
+        this.callbacks.onDrag?.(this.activeEntityId, this.activeGroup, nextX, nextY);
+    };
+
+    private onMouseUp = (event: MouseEvent): void => {
+        if (this.activeEntityId === null || !this.activeGroup) return;
+
+        const world = this.screenToWorld(event.clientX, event.clientY);
+        if (world) {
+            this.callbacks.onDrop?.(this.activeEntityId, this.activeGroup, world.x, world.y);
+        }
+
+        this.activeEntityId = null;
+        this.activeGroup = null;
+    };
+
+    private pickEntityGroup(clientX: number, clientY: number): { entityId: number; group: THREE.Group } | null {
+        const ndc = this.clientToNdc(clientX, clientY);
+        this.raycaster.setFromCamera(ndc, this.camera);
+
+        const hits = this.raycaster.intersectObjects(this.scene.children, true);
+        for (const hit of hits) {
+            const entityGroup = findAncestorEntityGroup(hit.object);
+            if (entityGroup) return entityGroup;
+        }
+        return null;
+    }
+
+    private screenToWorld(clientX: number, clientY: number): THREE.Vector3 | null {
+        const ndc = this.clientToNdc(clientX, clientY);
+        this.raycaster.setFromCamera(ndc, this.camera);
+        const out = new THREE.Vector3();
+        return this.raycaster.ray.intersectPlane(this.dragPlane, out) ? out : null;
+    }
+
+    private clientToNdc(clientX: number, clientY: number): THREE.Vector2 {
+        return new THREE.Vector2(
+            (clientX / window.innerWidth) * 2 - 1,
+            -(clientY / window.innerHeight) * 2 + 1,
+        );
+    }
+}
+
+function findAncestorEntityGroup(object: THREE.Object3D): { entityId: number; group: THREE.Group } | null {
+    let current: THREE.Object3D | null = object;
+    while (current) {
+        const entityId = (current.userData as { entityId?: unknown } | undefined)?.entityId;
+        if (typeof entityId === 'number' && current instanceof THREE.Group) {
+            return { entityId, group: current };
+        }
+        current = current.parent;
+    }
+    return null;
+}

--- a/src/battle_field_hand/renderer/BattleFieldHandRendererV2.ts
+++ b/src/battle_field_hand/renderer/BattleFieldHandRendererV2.ts
@@ -8,7 +8,7 @@ import {
 } from "../frame/BattleFieldHandLayoutFrame";
 import { HandCardRendererV2 } from "./HandCardRendererV2";
 
-interface HandEntry {
+export interface HandEntry {
     card: HandCard;
     cardIndex: number;
     group: THREE.Group;
@@ -71,5 +71,13 @@ export class BattleFieldHandRendererV2 {
             this.cardRenderer.dispose(entry.group);
         }
         handGroup.clear();
+    }
+
+    public getEntries(handGroup: THREE.Group): readonly HandEntry[] {
+        return (handGroup.userData as HandUserData).entries;
+    }
+
+    public getCardRenderer(): HandCardRendererV2 {
+        return this.cardRenderer;
     }
 }

--- a/src/battle_field_hand/renderer/HandCardRendererV2.ts
+++ b/src/battle_field_hand/renderer/HandCardRendererV2.ts
@@ -7,6 +7,7 @@ import { HandCard } from "../entity/HandCard";
 import { HandCardFrame, HandCardSlot } from "../frame/HandCardFrame";
 
 interface HandCardUserData {
+    entityId: number;
     baseCardWidth: number;
     baseCardHeight: number;
 }
@@ -63,7 +64,11 @@ export class HandCardRendererV2 {
             group.add(this.createEnergyTextMesh(entity.energyCount, energyPos, textScale));
         }
 
-        const userData: HandCardUserData = { baseCardWidth: cardWidth, baseCardHeight: cardHeight };
+        const userData: HandCardUserData = {
+            entityId: entity.cardId,
+            baseCardWidth: cardWidth,
+            baseCardHeight: cardHeight,
+        };
         group.userData = userData;
         return group;
     }

--- a/src/common/field_energy/frame/FieldEnergyCountHudFrame.ts
+++ b/src/common/field_energy/frame/FieldEnergyCountHudFrame.ts
@@ -1,0 +1,28 @@
+// Frame for the energy-count number rendered just above the field-energy button. Mirrors
+// showFieldEnergyCount() in src/common/field_energy/FieldEnergyCount.ts:
+//   display: top 65%, left 94.0%, transform translate(-50%, -50%)
+//   font:    baseFontSize 42 at baseViewportHeight 1080, color #fff, bold
+
+export interface FieldEnergyCountHudFrame {
+    readonly topPercent: string;
+    readonly leftPercent: string;
+    readonly transform: string;
+    readonly zIndex: string;
+    readonly color: string;
+    readonly fontWeight: string;
+    readonly baseViewportHeight: number;
+    readonly baseFontSize: number;
+}
+
+export function createDefaultFieldEnergyCountHudFrame(): FieldEnergyCountHudFrame {
+    return {
+        topPercent: '65%',
+        leftPercent: '94.0%',
+        transform: 'translate(-50%, -50%)',
+        zIndex: '1000',
+        color: '#fff',
+        fontWeight: 'bold',
+        baseViewportHeight: 1080,
+        baseFontSize: 42,
+    };
+}

--- a/src/common/field_energy/frame/FieldEnergyHudFrame.ts
+++ b/src/common/field_energy/frame/FieldEnergyHudFrame.ts
@@ -1,0 +1,35 @@
+// Frame for the field-energy HUD element — a fixed-position container holding a background
+// image and a centered numeric label. Mirrors showFieldEnergy() in src/common/field_energy/FieldEnergy.ts:
+//   container: top 82.4%, left 90.4%, width 7.2%
+//   label:     baseFont 48 at baseViewportHeight 1080, verticalOffsetRatio 0.1
+//   image:     resource/battle_field/field_energy/field_energy_button.png
+
+export interface FieldEnergyHudFrame {
+    readonly topPercent: string;
+    readonly leftPercent: string;
+    readonly widthPercent: string;
+    readonly zIndex: string;
+    readonly imageSrc: string;
+    readonly labelColor: string;
+    readonly labelFontFamily: string;
+    readonly labelTextShadow: string;
+    readonly baseViewportHeight: number;
+    readonly baseFontSize: number;
+    readonly labelVerticalOffsetRatio: number;
+}
+
+export function createDefaultFieldEnergyHudFrame(): FieldEnergyHudFrame {
+    return {
+        topPercent: '82.4%',
+        leftPercent: '90.4%',
+        widthPercent: '7.2%',
+        zIndex: '1000',
+        imageSrc: 'resource/battle_field/field_energy/field_energy_button.png',
+        labelColor: '#222',
+        labelFontFamily: "'Inter','Roboto','Helvetica','Arial',sans-serif",
+        labelTextShadow: '0 1px 2px rgba(255,255,255,0.6)',
+        baseViewportHeight: 1080,
+        baseFontSize: 48,
+        labelVerticalOffsetRatio: 0.1,
+    };
+}

--- a/src/common/field_energy/frame/FieldEnergyRaceHudFrame.ts
+++ b/src/common/field_energy/frame/FieldEnergyRaceHudFrame.ts
@@ -1,0 +1,28 @@
+// Frame for the race-icon HUD element sitting above the field-energy button. Mirrors
+// showFieldEnergyRace() in src/common/card_race/CardRace.ts:
+//   container: top 72.1%, left 92.35%, width 3.4%
+//   image:     resource/card_race/<raceId>.png  (originally via TextureManager "race" category)
+
+export interface FieldEnergyRaceHudFrame {
+    readonly topPercent: string;
+    readonly leftPercent: string;
+    readonly widthPercent: string;
+    readonly zIndex: string;
+    readonly imageSrcTemplate: string;
+    readonly raceId: number;
+}
+
+export function createDefaultFieldEnergyRaceHudFrame(raceId: number = 1): FieldEnergyRaceHudFrame {
+    return {
+        topPercent: '72.1%',
+        leftPercent: '92.35%',
+        widthPercent: '3.4%',
+        zIndex: '1000',
+        imageSrcTemplate: 'resource/card_race/{id}.png',
+        raceId,
+    };
+}
+
+export function resolveFieldEnergyRaceImageSrc(frame: FieldEnergyRaceHudFrame): string {
+    return frame.imageSrcTemplate.replace('{id}', String(frame.raceId));
+}

--- a/src/common/field_energy/renderer/FieldEnergyCountHudRendererV2.ts
+++ b/src/common/field_energy/renderer/FieldEnergyCountHudRendererV2.ts
@@ -1,0 +1,51 @@
+import { DomFrameRenderer } from "../../../core/renderer/DomFrameRenderer";
+import { FieldEnergyCountHudFrame } from "../frame/FieldEnergyCountHudFrame";
+
+// Mirrors showFieldEnergyCount() in src/common/field_energy/FieldEnergyCount.ts — a fixed,
+// translate(-50%, -50%) centered numeric div. Font size scales with viewport height on resize.
+export class FieldEnergyCountHudRendererV2 implements DomFrameRenderer<FieldEnergyCountHudFrame> {
+    private count: number;
+
+    constructor(initialCount: number = 0) {
+        this.count = initialCount;
+    }
+
+    public setCount(value: number): void {
+        this.count = value;
+    }
+
+    public async build(frame: FieldEnergyCountHudFrame): Promise<HTMLElement> {
+        const element = document.createElement('div');
+        element.style.position = 'fixed';
+        element.style.top = frame.topPercent;
+        element.style.left = frame.leftPercent;
+        element.style.transform = frame.transform;
+        element.style.color = frame.color;
+        element.style.fontWeight = frame.fontWeight;
+        element.style.zIndex = frame.zIndex;
+        element.style.pointerEvents = 'none';
+        element.innerText = String(this.count);
+
+        this.applyFontSize(frame, element, window.innerHeight);
+        return element;
+    }
+
+    public update(
+        frame: FieldEnergyCountHudFrame,
+        element: HTMLElement,
+        _viewportWidth: number,
+        viewportHeight: number,
+    ): void {
+        element.innerText = String(this.count);
+        this.applyFontSize(frame, element, viewportHeight);
+    }
+
+    public dispose(element: HTMLElement): void {
+        element.remove();
+    }
+
+    private applyFontSize(frame: FieldEnergyCountHudFrame, element: HTMLElement, viewportHeight: number): void {
+        const fontSize = (viewportHeight / frame.baseViewportHeight) * frame.baseFontSize;
+        element.style.fontSize = `${fontSize}px`;
+    }
+}

--- a/src/common/field_energy/renderer/FieldEnergyHudRendererV2.ts
+++ b/src/common/field_energy/renderer/FieldEnergyHudRendererV2.ts
@@ -1,0 +1,128 @@
+import { DomFrameRenderer } from "../../../core/renderer/DomFrameRenderer";
+import { FieldEnergyHudFrame } from "../frame/FieldEnergyHudFrame";
+
+interface BuildResult {
+    readonly element: HTMLElement;
+    readonly box: HTMLDivElement;
+    readonly img: HTMLImageElement;
+    readonly label: HTMLDivElement;
+}
+
+// Mirrors showFieldEnergy() in src/common/field_energy/FieldEnergy.ts:
+//   - fixed-position container + relative inner box + absolutely-positioned numeric label
+//   - label is appended to the box inside the image-load handler, so its top offset is
+//     calculated against the real image height (not 0 from a detached node)
+//   - build() returns synchronously after wiring listeners — image loading and the first
+//     layout pass run after the scenario appends the element, exactly as the legacy code does
+export class FieldEnergyHudRendererV2 implements DomFrameRenderer<FieldEnergyHudFrame> {
+    private energy: number;
+
+    constructor(initialEnergy: number = 0) {
+        this.energy = initialEnergy;
+    }
+
+    public setEnergy(value: number): void {
+        this.energy = value;
+    }
+
+    public build(frame: FieldEnergyHudFrame): Promise<HTMLElement> {
+        const container = document.createElement('div');
+        container.style.position = 'fixed';
+        container.style.top = frame.topPercent;
+        container.style.left = frame.leftPercent;
+        container.style.width = frame.widthPercent;
+        container.style.display = 'flex';
+        container.style.alignItems = 'center';
+        container.style.justifyContent = 'center';
+        container.style.zIndex = frame.zIndex;
+        container.style.pointerEvents = 'none';
+
+        const box = document.createElement('div');
+        box.style.position = 'relative';
+        box.style.width = '100%';
+        box.style.borderRadius = '6px';
+        box.style.overflow = 'hidden';
+
+        const img = document.createElement('img');
+        img.src = frame.imageSrc;
+        img.alt = 'field-energy-bg';
+        img.style.display = 'block';
+        img.style.width = '100%';
+        img.style.height = 'auto';
+        box.appendChild(img);
+
+        const label = document.createElement('div');
+        label.textContent = String(this.energy);
+        label.style.position = 'absolute';
+        label.style.left = '50%';
+        label.style.transform = 'translateX(-50%)';
+        label.style.color = frame.labelColor;
+        label.style.fontWeight = 'bold';
+        label.style.fontFamily = frame.labelFontFamily;
+        label.style.textShadow = frame.labelTextShadow;
+        label.style.textAlign = 'center';
+        // Intentionally not appending the label to the box yet — the image-load handler does
+        // it so label height can be measured after DOM attachment (see updateLabelPosition).
+
+        container.appendChild(box);
+
+        const buildResult: BuildResult = { element: container, box, img, label };
+        (container as HTMLElement & { __buildResult?: BuildResult }).__buildResult = buildResult;
+
+        const updateLabelPosition = (): void => {
+            if (!container.isConnected) {
+                // Caller hasn't appended the element yet — try again next frame.
+                requestAnimationFrame(updateLabelPosition);
+                return;
+            }
+            this.applyLabelGeometry(frame, buildResult, window.innerHeight);
+        };
+
+        img.addEventListener('load', updateLabelPosition);
+        img.addEventListener('error', () => {
+            console.warn(`FieldEnergyHudRendererV2: image failed to load — ${frame.imageSrc}`);
+            updateLabelPosition();
+        });
+        if (img.complete && img.naturalWidth > 0) {
+            // Image came from cache; schedule the layout pass after the caller has appended.
+            requestAnimationFrame(updateLabelPosition);
+        }
+
+        return Promise.resolve(container);
+    }
+
+    public update(
+        frame: FieldEnergyHudFrame,
+        element: HTMLElement,
+        _viewportWidth: number,
+        viewportHeight: number,
+    ): void {
+        const build = (element as HTMLElement & { __buildResult?: BuildResult }).__buildResult;
+        if (!build) return;
+        build.label.textContent = String(this.energy);
+        this.applyLabelGeometry(frame, build, viewportHeight);
+    }
+
+    public dispose(element: HTMLElement): void {
+        element.remove();
+    }
+
+    private applyLabelGeometry(
+        frame: FieldEnergyHudFrame,
+        build: BuildResult,
+        viewportHeight: number,
+    ): void {
+        const fontSize = (viewportHeight / frame.baseViewportHeight) * frame.baseFontSize;
+        build.label.style.fontSize = `${fontSize}px`;
+        build.label.style.lineHeight = 'normal';
+
+        if (!build.box.contains(build.label)) {
+            build.box.appendChild(build.label);
+        }
+
+        const textHeight = build.label.getBoundingClientRect().height;
+        const imgHeight = build.img.getBoundingClientRect().height;
+        const offset = fontSize * frame.labelVerticalOffsetRatio;
+        build.label.style.top = `${(imgHeight - textHeight) / 2 + offset}px`;
+    }
+}

--- a/src/common/field_energy/renderer/FieldEnergyRaceHudRendererV2.ts
+++ b/src/common/field_energy/renderer/FieldEnergyRaceHudRendererV2.ts
@@ -1,0 +1,51 @@
+import { DomFrameRenderer } from "../../../core/renderer/DomFrameRenderer";
+import {
+    FieldEnergyRaceHudFrame,
+    resolveFieldEnergyRaceImageSrc,
+} from "../frame/FieldEnergyRaceHudFrame";
+
+// Mirrors showFieldEnergyRace() in src/common/card_race/CardRace.ts — container with an <img>
+// whose width flexes via CSS percentage. No font geometry to recalc, so update() is effectively
+// "swap image src if frame.raceId changed since build".
+export class FieldEnergyRaceHudRendererV2 implements DomFrameRenderer<FieldEnergyRaceHudFrame> {
+    public async build(frame: FieldEnergyRaceHudFrame): Promise<HTMLElement> {
+        const container = document.createElement('div');
+        container.style.position = 'fixed';
+        container.style.top = frame.topPercent;
+        container.style.left = frame.leftPercent;
+        container.style.width = frame.widthPercent;
+        container.style.display = 'flex';
+        container.style.alignItems = 'center';
+        container.style.justifyContent = 'center';
+        container.style.zIndex = frame.zIndex;
+        container.style.pointerEvents = 'none';
+
+        const img = document.createElement('img');
+        img.src = resolveFieldEnergyRaceImageSrc(frame);
+        img.alt = `field-energy-race-${frame.raceId}`;
+        img.style.width = '100%';
+        img.style.height = 'auto';
+        container.appendChild(img);
+
+        return container;
+    }
+
+    public update(
+        frame: FieldEnergyRaceHudFrame,
+        element: HTMLElement,
+        _viewportWidth: number,
+        _viewportHeight: number,
+    ): void {
+        const img = element.querySelector('img');
+        if (!(img instanceof HTMLImageElement)) return;
+        const desired = resolveFieldEnergyRaceImageSrc(frame);
+        if (!img.src.endsWith(desired)) {
+            img.src = desired;
+            img.alt = `field-energy-race-${frame.raceId}`;
+        }
+    }
+
+    public dispose(element: HTMLElement): void {
+        element.remove();
+    }
+}

--- a/src/core/renderer/DomFrameRenderer.ts
+++ b/src/core/renderer/DomFrameRenderer.ts
@@ -1,0 +1,11 @@
+// DOM-overlay variant of FrameRenderer<F>. Used for HUD elements that live in the HTML layer
+// (fixed-position divs on top of the WebGL canvas) rather than as THREE.Group meshes.
+//
+// Same build / update / dispose contract, but build returns an HTMLElement the scenario
+// appends to document.body (or any container), and update is called on window resize so the
+// Renderer can recompute font sizes / absolute offsets that don't reflow via pure CSS.
+export interface DomFrameRenderer<F> {
+    build(frame: F): Promise<HTMLElement>;
+    update(frame: F, element: HTMLElement, viewportWidth: number, viewportHeight: number): void;
+    dispose(element: HTMLElement): void;
+}

--- a/src/your_field_area/frame/PlacedCardPlacementFrame.ts
+++ b/src/your_field_area/frame/PlacedCardPlacementFrame.ts
@@ -1,0 +1,26 @@
+// Single-slot placement frame for a card dropped onto your field area.
+// Pilot C uses a single center slot; later pilots can extend this into a grid.
+
+export interface PlacedCardPlacementFrame {
+    readonly xPercent: number;
+    readonly yPercent: number;
+}
+
+export function createDefaultPlacedCardPlacementFrame(): PlacedCardPlacementFrame {
+    // Default: same center as the field area (yPercent mirrors YourFieldAreaFrame default).
+    return {
+        xPercent: 0,
+        yPercent: -0.5 + (0.024 * 3 + 0.11 * 2.5),
+    };
+}
+
+export function computePlacedCardPosition(
+    frame: PlacedCardPlacementFrame,
+    viewportWidth: number,
+    viewportHeight: number,
+): { x: number; y: number } {
+    return {
+        x: frame.xPercent * viewportWidth,
+        y: frame.yPercent * viewportHeight,
+    };
+}

--- a/src/your_field_area/frame/YourFieldAreaFrame.ts
+++ b/src/your_field_area/frame/YourFieldAreaFrame.ts
@@ -23,3 +23,28 @@ export function createDefaultYourFieldAreaFrame(): YourFieldAreaFrame {
         renderOrder: 1,
     };
 }
+
+export interface YourFieldAreaBounds {
+    readonly minX: number;
+    readonly maxX: number;
+    readonly minY: number;
+    readonly maxY: number;
+}
+
+// World-space axis-aligned bounds of the field area. Used for drop-hit tests.
+export function computeYourFieldAreaBounds(
+    frame: YourFieldAreaFrame,
+    viewportWidth: number,
+    viewportHeight: number,
+): YourFieldAreaBounds {
+    const centerX = frame.xPercent * viewportWidth;
+    const centerY = frame.yPercent * viewportHeight;
+    const halfWidth = (frame.widthPercent * viewportWidth) / 2;
+    const halfHeight = (frame.heightPercent * viewportHeight) / 2;
+    return {
+        minX: centerX - halfWidth,
+        maxX: centerX + halfWidth,
+        minY: centerY - halfHeight,
+        maxY: centerY + halfHeight,
+    };
+}

--- a/test/draw_field_energy_hud_efr/config/webpack.common.js
+++ b/test/draw_field_energy_hud_efr/config/webpack.common.js
@@ -1,0 +1,42 @@
+const path = require("path");
+
+module.exports = {
+    entry: {
+        draw_field_energy_hud_efr: "./test/draw_field_energy_hud_efr/draw_field_energy_hud_efr.ts",
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.(png|jpg|gif)$/i,
+                type: 'asset/resource',
+            },
+            {
+                test: /\.json$/,
+                type: 'json',
+            },
+            {
+                test: /\.mp3$/,
+                use: 'file-loader',
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".tsx", ".ts", ".js"],
+        alias: {
+            '@resource': path.resolve(__dirname, '../../../resource'),
+        },
+        fallback: {
+            "fs": false,
+            "path": false,
+        },
+    },
+    output: {
+        filename: "bundle.js",
+        path: path.resolve(__dirname, "../../dist/draw_field_energy_hud_efr"),
+    },
+};

--- a/test/draw_field_energy_hud_efr/config/webpack.dev.js
+++ b/test/draw_field_energy_hud_efr/config/webpack.dev.js
@@ -1,0 +1,17 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+const path = require("path");
+
+module.exports = merge(common, {
+    mode: "development",
+    devtool: "eval-source-map",
+    devServer: {
+        static: [
+            { directory: path.join(__dirname, "../") },
+            { directory: path.join(__dirname, "../../../") },
+            { directory: path.join(__dirname, "../../../resource") },
+        ],
+        hot: true,
+        historyApiFallback: true,
+    },
+});

--- a/test/draw_field_energy_hud_efr/draw_field_energy_hud_efr.ts
+++ b/test/draw_field_energy_hud_efr/draw_field_energy_hud_efr.ts
@@ -1,0 +1,214 @@
+import * as THREE from "three";
+
+import { CameraManager } from "../../src/core/camera/CameraManager";
+import { RendererManager } from "../../src/core/renderer/RendererManager";
+import { SceneManager } from "../../src/core/scene/SceneManager";
+import { AnimationLoop } from "../../src/core/animation/AnimationLoop";
+
+import { createBattleFieldBackgroundFrame } from "../../src/background/frame/BackgroundFrame";
+import { BackgroundRendererV2 } from "../../src/background/renderer/BackgroundRendererV2";
+
+import {
+    createDefaultYourFieldAreaFrame,
+    computeYourFieldAreaBounds,
+} from "../../src/your_field_area/frame/YourFieldAreaFrame";
+import { YourFieldAreaRendererV2 } from "../../src/your_field_area/renderer/YourFieldAreaRendererV2";
+import {
+    createDefaultPlacedCardPlacementFrame,
+    computePlacedCardPosition,
+} from "../../src/your_field_area/frame/PlacedCardPlacementFrame";
+
+import { BattleFieldHandMapRepositoryImpl } from "../../src/battle_field_hand/repository/BattleFieldHandMapRepositoryImpl";
+import { HandCard } from "../../src/battle_field_hand/entity/HandCard";
+import { createDefaultHandCardFrame } from "../../src/battle_field_hand/frame/HandCardFrame";
+import {
+    createDefaultBattleFieldHandLayoutFrame,
+    computeHandCardCenter,
+} from "../../src/battle_field_hand/frame/BattleFieldHandLayoutFrame";
+import { BattleFieldHandRendererV2 } from "../../src/battle_field_hand/renderer/BattleFieldHandRendererV2";
+import { HandInteractionBridge } from "../../src/battle_field_hand/interaction/HandInteractionBridge";
+
+import { getCardById } from "../../src/card/utility";
+import { CardJob } from "../../src/card/job";
+import { CardKind } from "../../src/card/kind";
+
+import { createDefaultFieldEnergyHudFrame } from "../../src/common/field_energy/frame/FieldEnergyHudFrame";
+import { FieldEnergyHudRendererV2 } from "../../src/common/field_energy/renderer/FieldEnergyHudRendererV2";
+import { createDefaultFieldEnergyRaceHudFrame } from "../../src/common/field_energy/frame/FieldEnergyRaceHudFrame";
+import { FieldEnergyRaceHudRendererV2 } from "../../src/common/field_energy/renderer/FieldEnergyRaceHudRendererV2";
+import { createDefaultFieldEnergyCountHudFrame } from "../../src/common/field_energy/frame/FieldEnergyCountHudFrame";
+import { FieldEnergyCountHudRendererV2 } from "../../src/common/field_energy/renderer/FieldEnergyCountHudRendererV2";
+
+const rootElement = document.getElementById('app');
+if (!rootElement) {
+    throw new Error("Cannot find element with id 'app'.");
+}
+
+type CardLocation = 'hand' | 'placed';
+
+function resolveHandCards(cardIds: number[]): HandCard[] {
+    const hand: HandCard[] = [];
+    for (const cardId of cardIds) {
+        const card = getCardById(cardId);
+        if (!card) {
+            console.warn(`Card ${cardId} not found in every_card_info — skipping.`);
+            continue;
+        }
+        hand.push({
+            cardId,
+            cardKind: parseInt(card.종류, 10) as CardKind,
+            unitJob: parseInt(card.병종, 10) as CardJob,
+            raceId: parseInt(card.종족, 10),
+            hpId: card.체력,
+            attackPowerId: card.공격력,
+            kindId: parseInt(card.종류, 10),
+            energyCount: 0,
+        });
+    }
+    return hand;
+}
+
+async function main(container: HTMLElement): Promise<void> {
+    const rendererManager = new RendererManager(container);
+    const sceneManager = new SceneManager();
+    const cameraManager = CameraManager.getInstance();
+
+    const aspectRatio = window.innerWidth / window.innerHeight;
+    const viewSize = window.innerHeight;
+    const camera = cameraManager.createAndSetActiveCamera(aspectRatio, viewSize);
+
+    const scene = sceneManager.createScene('draw-field-energy-hud-efr');
+
+    // Pilot A — background + your field area
+    const backgroundFrame = createBattleFieldBackgroundFrame();
+    const backgroundRenderer = new BackgroundRendererV2();
+    const backgroundGroup = await backgroundRenderer.build(backgroundFrame);
+    scene.add(backgroundGroup);
+
+    const yourFieldAreaFrame = createDefaultYourFieldAreaFrame();
+    const yourFieldAreaRenderer = new YourFieldAreaRendererV2();
+    const yourFieldAreaGroup = await yourFieldAreaRenderer.build(yourFieldAreaFrame);
+    scene.add(yourFieldAreaGroup);
+
+    // Pilot B — hand row
+    const placementFrame = createDefaultPlacedCardPlacementFrame();
+
+    const handCardIds = BattleFieldHandMapRepositoryImpl.getInstance().getBattleFieldHandList();
+    const hand = resolveHandCards(handCardIds);
+
+    const handCardFrame = createDefaultHandCardFrame();
+    const handLayoutFrame = createDefaultBattleFieldHandLayoutFrame();
+    const handRenderer = new BattleFieldHandRendererV2();
+    const handGroup = await handRenderer.build(hand, handCardFrame, handLayoutFrame);
+    scene.add(handGroup);
+
+    const cardLocation = new Map<number, CardLocation>();
+    const entries = handRenderer.getEntries(handGroup);
+    for (const entry of entries) {
+        cardLocation.set(entry.card.cardId, 'hand');
+    }
+
+    const animationLoop = new AnimationLoop(rendererManager, sceneManager, cameraManager);
+    animationLoop.start();
+
+    // Pilot C — click / drag / drop
+    const bridge = new HandInteractionBridge(
+        rendererManager.getDomElement(),
+        camera,
+        scene,
+        {
+            onPickup: (_entityId, group) => {
+                group.renderOrder = 100;
+                group.position.z = 1;
+            },
+            onDrop: (entityId, group, worldX, worldY) => {
+                group.renderOrder = 0;
+                group.position.z = 0;
+
+                const bounds = computeYourFieldAreaBounds(
+                    yourFieldAreaFrame,
+                    window.innerWidth,
+                    window.innerHeight,
+                );
+                const inside =
+                    worldX >= bounds.minX && worldX <= bounds.maxX &&
+                    worldY >= bounds.minY && worldY <= bounds.maxY;
+
+                if (inside) {
+                    const { x, y } = computePlacedCardPosition(
+                        placementFrame,
+                        window.innerWidth,
+                        window.innerHeight,
+                    );
+                    group.position.set(x, y, 0);
+                    cardLocation.set(entityId, 'placed');
+                } else {
+                    snapBackToHand(entityId, group);
+                }
+            },
+        },
+    );
+    bridge.attach();
+
+    function snapBackToHand(entityId: number, group: THREE.Group): void {
+        const entry = entries.find((e) => e.card.cardId === entityId);
+        if (!entry) return;
+        const { x, y } = computeHandCardCenter(
+            handLayoutFrame,
+            entry.cardIndex,
+            window.innerWidth,
+            window.innerHeight,
+        );
+        group.position.set(x, y, 0);
+        cardLocation.set(entityId, 'hand');
+    }
+
+    // Pilot D-1 — field-energy HUD overlays (new to this pilot)
+    const energyFrame = createDefaultFieldEnergyHudFrame();
+    const energyRenderer = new FieldEnergyHudRendererV2(7);
+    const energyElement = await energyRenderer.build(energyFrame);
+    document.body.appendChild(energyElement);
+
+    const raceFrame = createDefaultFieldEnergyRaceHudFrame(1);
+    const raceRenderer = new FieldEnergyRaceHudRendererV2();
+    const raceElement = await raceRenderer.build(raceFrame);
+    document.body.appendChild(raceElement);
+
+    const countFrame = createDefaultFieldEnergyCountHudFrame();
+    const countRenderer = new FieldEnergyCountHudRendererV2(1);
+    const countElement = await countRenderer.build(countFrame);
+    document.body.appendChild(countElement);
+
+    window.addEventListener('resize', () => {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+
+        cameraManager.updateAspect(width, height);
+        rendererManager.resize(width, height);
+
+        backgroundRenderer.resize(backgroundFrame, backgroundGroup, width, height);
+        yourFieldAreaRenderer.resize(yourFieldAreaFrame, yourFieldAreaGroup, width, height);
+
+        const cardRenderer = handRenderer.getCardRenderer();
+        for (const entry of entries) {
+            cardRenderer.resize(handCardFrame, entry.group);
+
+            const location = cardLocation.get(entry.card.cardId);
+            if (location === 'placed') {
+                const { x, y } = computePlacedCardPosition(placementFrame, width, height);
+                entry.group.position.set(x, y, 0);
+            } else {
+                const { x, y } = computeHandCardCenter(handLayoutFrame, entry.cardIndex, width, height);
+                entry.group.position.set(x, y, 0);
+            }
+        }
+
+        energyRenderer.update(energyFrame, energyElement, width, height);
+        raceRenderer.update(raceFrame, raceElement, width, height);
+        countRenderer.update(countFrame, countElement, width, height);
+    });
+}
+
+main(rootElement).catch((error) => {
+    console.error('draw_field_energy_hud_efr failed to start:', error);
+});

--- a/test/draw_field_energy_hud_efr/index.html
+++ b/test/draw_field_energy_hud_efr/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EDDI TCG — draw_field_energy_hud_efr</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+            background: #111;
+        }
+        #app {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="app"></div>
+    <script type="module" src="bundle.js"></script>
+</body>
+</html>

--- a/test/draw_your_field_interactive_efr/config/webpack.common.js
+++ b/test/draw_your_field_interactive_efr/config/webpack.common.js
@@ -1,0 +1,42 @@
+const path = require("path");
+
+module.exports = {
+    entry: {
+        draw_your_field_interactive_efr: "./test/draw_your_field_interactive_efr/draw_your_field_interactive_efr.ts",
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.(png|jpg|gif)$/i,
+                type: 'asset/resource',
+            },
+            {
+                test: /\.json$/,
+                type: 'json',
+            },
+            {
+                test: /\.mp3$/,
+                use: 'file-loader',
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".tsx", ".ts", ".js"],
+        alias: {
+            '@resource': path.resolve(__dirname, '../../../resource'),
+        },
+        fallback: {
+            "fs": false,
+            "path": false,
+        },
+    },
+    output: {
+        filename: "bundle.js",
+        path: path.resolve(__dirname, "../../dist/draw_your_field_interactive_efr"),
+    },
+};

--- a/test/draw_your_field_interactive_efr/config/webpack.dev.js
+++ b/test/draw_your_field_interactive_efr/config/webpack.dev.js
@@ -1,0 +1,17 @@
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+const path = require("path");
+
+module.exports = merge(common, {
+    mode: "development",
+    devtool: "eval-source-map",
+    devServer: {
+        static: [
+            { directory: path.join(__dirname, "../") },
+            { directory: path.join(__dirname, "../../../") },
+            { directory: path.join(__dirname, "../../../resource") },
+        ],
+        hot: true,
+        historyApiFallback: true,
+    },
+});

--- a/test/draw_your_field_interactive_efr/draw_your_field_interactive_efr.ts
+++ b/test/draw_your_field_interactive_efr/draw_your_field_interactive_efr.ts
@@ -1,0 +1,185 @@
+import * as THREE from "three";
+
+import { CameraManager } from "../../src/core/camera/CameraManager";
+import { RendererManager } from "../../src/core/renderer/RendererManager";
+import { SceneManager } from "../../src/core/scene/SceneManager";
+import { AnimationLoop } from "../../src/core/animation/AnimationLoop";
+
+import { createBattleFieldBackgroundFrame } from "../../src/background/frame/BackgroundFrame";
+import { BackgroundRendererV2 } from "../../src/background/renderer/BackgroundRendererV2";
+
+import {
+    createDefaultYourFieldAreaFrame,
+    computeYourFieldAreaBounds,
+} from "../../src/your_field_area/frame/YourFieldAreaFrame";
+import { YourFieldAreaRendererV2 } from "../../src/your_field_area/renderer/YourFieldAreaRendererV2";
+
+import {
+    createDefaultPlacedCardPlacementFrame,
+    computePlacedCardPosition,
+} from "../../src/your_field_area/frame/PlacedCardPlacementFrame";
+
+import { BattleFieldHandMapRepositoryImpl } from "../../src/battle_field_hand/repository/BattleFieldHandMapRepositoryImpl";
+import { HandCard } from "../../src/battle_field_hand/entity/HandCard";
+import { createDefaultHandCardFrame } from "../../src/battle_field_hand/frame/HandCardFrame";
+import {
+    createDefaultBattleFieldHandLayoutFrame,
+    computeHandCardCenter,
+} from "../../src/battle_field_hand/frame/BattleFieldHandLayoutFrame";
+import { BattleFieldHandRendererV2 } from "../../src/battle_field_hand/renderer/BattleFieldHandRendererV2";
+import { HandInteractionBridge } from "../../src/battle_field_hand/interaction/HandInteractionBridge";
+
+import { getCardById } from "../../src/card/utility";
+import { CardJob } from "../../src/card/job";
+import { CardKind } from "../../src/card/kind";
+
+const rootElement = document.getElementById('app');
+if (!rootElement) {
+    throw new Error("Cannot find element with id 'app'.");
+}
+
+type CardLocation = 'hand' | 'placed';
+
+function resolveHandCards(cardIds: number[]): HandCard[] {
+    const hand: HandCard[] = [];
+    for (const cardId of cardIds) {
+        const card = getCardById(cardId);
+        if (!card) {
+            console.warn(`Card ${cardId} not found in every_card_info — skipping.`);
+            continue;
+        }
+        hand.push({
+            cardId,
+            cardKind: parseInt(card.종류, 10) as CardKind,
+            unitJob: parseInt(card.병종, 10) as CardJob,
+            raceId: parseInt(card.종족, 10),
+            hpId: card.체력,
+            attackPowerId: card.공격력,
+            kindId: parseInt(card.종류, 10),
+            energyCount: 0,
+        });
+    }
+    return hand;
+}
+
+async function main(container: HTMLElement): Promise<void> {
+    const rendererManager = new RendererManager(container);
+    const sceneManager = new SceneManager();
+    const cameraManager = CameraManager.getInstance();
+
+    const aspectRatio = window.innerWidth / window.innerHeight;
+    const viewSize = window.innerHeight;
+    const camera = cameraManager.createAndSetActiveCamera(aspectRatio, viewSize);
+
+    const scene = sceneManager.createScene('draw-your-field-interactive-efr');
+
+    const backgroundFrame = createBattleFieldBackgroundFrame();
+    const backgroundRenderer = new BackgroundRendererV2();
+    const backgroundGroup = await backgroundRenderer.build(backgroundFrame);
+    scene.add(backgroundGroup);
+
+    const yourFieldAreaFrame = createDefaultYourFieldAreaFrame();
+    const yourFieldAreaRenderer = new YourFieldAreaRendererV2();
+    const yourFieldAreaGroup = await yourFieldAreaRenderer.build(yourFieldAreaFrame);
+    scene.add(yourFieldAreaGroup);
+
+    const placementFrame = createDefaultPlacedCardPlacementFrame();
+
+    const handCardIds = BattleFieldHandMapRepositoryImpl.getInstance().getBattleFieldHandList();
+    const hand = resolveHandCards(handCardIds);
+
+    const handCardFrame = createDefaultHandCardFrame();
+    const handLayoutFrame = createDefaultBattleFieldHandLayoutFrame();
+    const handRenderer = new BattleFieldHandRendererV2();
+    const handGroup = await handRenderer.build(hand, handCardFrame, handLayoutFrame);
+    scene.add(handGroup);
+
+    const cardLocation = new Map<number, CardLocation>();
+    const entries = handRenderer.getEntries(handGroup);
+    for (const entry of entries) {
+        cardLocation.set(entry.card.cardId, 'hand');
+    }
+
+    const animationLoop = new AnimationLoop(rendererManager, sceneManager, cameraManager);
+    animationLoop.start();
+
+    const bridge = new HandInteractionBridge(
+        rendererManager.getDomElement(),
+        camera,
+        scene,
+        {
+            onPickup: (_entityId, group) => {
+                group.renderOrder = 100;
+                group.position.z = 1;
+            },
+            onDrop: (entityId, group, worldX, worldY) => {
+                group.renderOrder = 0;
+                group.position.z = 0;
+
+                const bounds = computeYourFieldAreaBounds(
+                    yourFieldAreaFrame,
+                    window.innerWidth,
+                    window.innerHeight,
+                );
+                const inside =
+                    worldX >= bounds.minX && worldX <= bounds.maxX &&
+                    worldY >= bounds.minY && worldY <= bounds.maxY;
+
+                if (inside) {
+                    const { x, y } = computePlacedCardPosition(
+                        placementFrame,
+                        window.innerWidth,
+                        window.innerHeight,
+                    );
+                    group.position.set(x, y, 0);
+                    cardLocation.set(entityId, 'placed');
+                } else {
+                    snapBackToHand(entityId, group);
+                }
+            },
+        },
+    );
+    bridge.attach();
+
+    function snapBackToHand(entityId: number, group: THREE.Group): void {
+        const entry = entries.find((e) => e.card.cardId === entityId);
+        if (!entry) return;
+        const { x, y } = computeHandCardCenter(
+            handLayoutFrame,
+            entry.cardIndex,
+            window.innerWidth,
+            window.innerHeight,
+        );
+        group.position.set(x, y, 0);
+        cardLocation.set(entityId, 'hand');
+    }
+
+    window.addEventListener('resize', () => {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+
+        cameraManager.updateAspect(width, height);
+        rendererManager.resize(width, height);
+        backgroundRenderer.resize(backgroundFrame, backgroundGroup, width, height);
+        yourFieldAreaRenderer.resize(yourFieldAreaFrame, yourFieldAreaGroup, width, height);
+
+        // Rescale every hand card (uniform scale reacts to new cardWidth/cardHeight).
+        const cardRenderer = handRenderer.getCardRenderer();
+        for (const entry of entries) {
+            cardRenderer.resize(handCardFrame, entry.group);
+
+            const location = cardLocation.get(entry.card.cardId);
+            if (location === 'placed') {
+                const { x, y } = computePlacedCardPosition(placementFrame, width, height);
+                entry.group.position.set(x, y, 0);
+            } else {
+                const { x, y } = computeHandCardCenter(handLayoutFrame, entry.cardIndex, width, height);
+                entry.group.position.set(x, y, 0);
+            }
+        }
+    });
+}
+
+main(rootElement).catch((error) => {
+    console.error('draw_your_field_interactive_efr failed to start:', error);
+});

--- a/test/draw_your_field_interactive_efr/index.html
+++ b/test/draw_your_field_interactive_efr/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EDDI TCG — draw_your_field_interactive_efr</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+            background: #111;
+        }
+        #app {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="app"></div>
+    <script type="module" src="bundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Raycaster(scene/camera 결합)는 입력 계층에 그대로 두고, 히트된 mesh → Entity ID 해석만 EFR이 담당하며 draw_your_field_with_hand_efr(배경 + 필드 영역 + 핸드 행)에 마우스 입력을 얹어, 핸드 카드를 잡아 내 필드 영역으로 드래그 앤 드롭하는 동작을 EFR 구조로 구현한다 [ETWGL-4]